### PR TITLE
Support branching in static analysis

### DIFF
--- a/src/loaders/relocate-loader.js
+++ b/src/loaders/relocate-loader.js
@@ -3,7 +3,7 @@ const { readFile, stat, statSync, existsSync } = require('graceful-fs');
 const { walk } = require('estree-walker');
 const MagicString = require('magic-string');
 const { attachScopes } = require('rollup-pluginutils');
-const evaluate = require('static-eval');
+const evaluate = require('../utils/static-eval');
 const acorn = require('acorn');
 const bindings = require('bindings');
 const getUniqueAssetName = require('../utils/dedupe-names');
@@ -302,8 +302,12 @@ module.exports = function (code) {
       else if (node.type === 'CallExpression' && !isESM &&
           isStaticRequire(node.callee) &&
           node.callee.arguments[0].value === 'bindings') {
-        staticChildValue = createBindings()(computeStaticValue(node.arguments[0], true));
-        if (staticChildValue) {
+        let staticValue = computeStaticValue(node.arguments[0], true);
+        let bindingsValue;
+        if (staticValue && 'value' in staticValue)
+          bindingsValue = createBindings()(staticValue.value);
+        if (bindingsValue) {
+          staticChildValue = { value: bindingsValue };
           staticChildNode = node;
           staticChildValueBindingsInstance = staticBindingsInstance;
           return this.skip();
@@ -322,7 +326,10 @@ module.exports = function (code) {
           node.callee.object.name === nbindId &&
           node.callee.property.type === 'Identifier' &&
           node.callee.property.name === 'init') {
-        const bindingInfo = computeStaticValue(node, false);
+        const staticValue = computeStaticValue(node, false);
+        let bindingInfo;
+        if (staticValue && 'value' in staticValue)
+          bindingInfo = staticValue.value;
         if (bindingInfo) {
           bindingInfo.path = path.relative(path.dirname(id), bindingInfo.path);
           transformed = true;
@@ -429,7 +436,7 @@ module.exports = function (code) {
       // -> compute and backtrack
       if (staticChildNode) {
         const curStaticValue = computeStaticValue(node, false);
-        if (curStaticValue !== undefined) {
+        if (curStaticValue) {
           staticChildValue = curStaticValue;
           staticChildNode = node;
           staticChildValueBindingsInstance = staticBindingsInstance;
@@ -439,40 +446,59 @@ module.exports = function (code) {
         if (staticChildNode.type === 'Identifier' && staticChildNode.name === '__filename' ||
             staticChildNode.type === 'ReturnStatement' && staticChildNode.argument.type === 'Identifier' &&
             staticChildNode.argument.name === '__filename') {
-          staticChildNode = staticChilValue = undefined;
+          staticChildNode = staticChildValue = undefined;
           return;
         }
         // no static value -> see if we should emit the asset if it exists
         // Currently we only handle files. In theory whole directories could also be emitted if necessary.
-        let stats;
-        if (typeof staticChildValue === 'string') {
-          try {
-            stats = statSync(staticChildValue);
-          }
-          catch (e) {}
-        }
-        // Boolean inlining
-        else if (typeof staticChildValue === 'boolean') {
-          transformed = true;
-          magicString.overwrite(staticChildNode.start, staticChildNode.end, String(staticChildValue));
-        }
-        if (stats && stats.isFile()) {
-          let replacement = emitAsset(path.resolve(staticChildValue));
-          // require('bindings')(...)
-          // -> require(require('bindings')(...))
-          if (staticChildValueBindingsInstance) {
-            replacement = '__non_webpack_require__(' + replacement + ')';
-          }
-          if (replacement) {
+        if ('value' in staticChildValue) {
+          const inlineString = getInlined(inlineType(staticChildValue.value), staticChildValue.value);
+          if (inlineString) {
+            magicString.overwrite(staticChildNode.start, staticChildNode.end, inlineString);
             transformed = true;
-            magicString.overwrite(staticChildNode.start, staticChildNode.end, replacement);
           }
         }
-        else if (stats && stats.isDirectory()) {
-          let replacement = emitAssetDirectory(path.resolve(staticChildValue));
-          if (replacement) {
+        else {
+          const thenInlineType = inlineType(staticChildValue.then);
+          const elseInlineType = inlineType(staticChildValue.else);
+          // only inline conditionals when both branches are known inlinings
+          if (thenInlineType && elseInlineType) {
+            const thenInlineString = getInlined(thenInlineType, staticChildValue.then);
+            const elseInlineString = getInlined(elseInlineType, staticChildValue.else);
+            magicString.overwrite(
+              staticChildNode.start, staticChildNode.end,
+              `${code.substring(staticChildValue.test.start, staticChildValue.test.end)} ? ${thenInlineString} : ${elseInlineString}`
+            );
             transformed = true;
-            magicString.overwrite(staticChildNode.start, staticChildNode.end, replacement);
+          }
+        }
+        function inlineType (value) {
+          let stats;
+          if (typeof value === 'string') {
+            try {
+              stats = statSync(value);
+            }
+            catch (e) {}
+          }
+          else if (typeof value === 'boolean')
+            return 'value';
+          if (stats && stats.isFile())
+            return 'file';
+          else if (stats && stats.isDirectory())
+            return 'directory';
+        }
+        function getInlined (inlineType, value) {
+          switch (inlineType) {
+            case 'value': return String(value);
+            case 'file':
+              let replacement = emitAsset(path.resolve(value));
+              // require('bindings')(...)
+              // -> require(require('bindings')(...))
+              if (staticChildValueBindingsInstance)
+                replacement = '__non_webpack_require__(' + replacement + ')';
+              return replacement;
+            case 'directory':
+              return emitAssetDirectory(path.resolve(value));
           }
         }
         staticChildNode = staticChildValue = undefined;

--- a/src/utils/static-eval.js
+++ b/src/utils/static-eval.js
@@ -1,0 +1,299 @@
+/*
+ * Adapted from https://github.com/substack/static-eval
+ * © 2013 - 2017 substack (James Halliday)
+ *
+ * This software is released under the MIT license:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// var unparse = require('escodegen').generate;
+
+module.exports = function (ast, vars = {}) {
+  return walk(ast);
+
+  // walk returns:
+  // 1. Single known value: { value: value }
+  // 2. Conditional value: { test, then, else }
+  // 3. Unknown value: undefined
+
+  function walk (node, scopeVars) {
+    if (node.type === 'Literal') {
+      return { value: node.value };
+    }
+    else if (node.type === 'UnaryExpression'){
+      var val = walk(node.argument);
+      if ('value' in val) {
+        if (node.operator === '+') return { value: +val.value };
+        if (node.operator === '-') return { value: -val.value };
+        if (node.operator === '~') return { value: ~val.value };
+        if (node.operator === '!') return { value: !val.value };
+      }
+      else if ('test' in val) {
+        if (node.operator === '+') return { test: val.test, then: +val.then, else: +val.else };
+        if (node.operator === '-') return { test: val.test, then: -val.then, else: -val.else };
+        if (node.operator === '~') return { test: val.test, then: ~val.then, else: ~val.else };
+        if (node.operator === '!') return { test: val.test, then: !val.then, else: !val.else };
+      }
+      return;
+    }
+    else if (node.type === 'ArrayExpression') {
+      var xs = [];
+      for (var i = 0, l = node.elements.length; i < l; i++) {
+        var x = walk(node.elements[i]);
+        if (!x) return;
+        if ('test' in x) return;          
+        xs.push(x.value);
+      }
+      return { value: xs };
+    }
+    else if (node.type === 'ObjectExpression') {
+      var obj = {};
+      for (var i = 0; i < node.properties.length; i++) {
+        var prop = node.properties[i];
+        var keyValue = prop.computed ? walk(prop.key) : { value: prop.key.name || prop.key.value };
+        if (!keyValue || 'test' in keyValue) return;
+        var value = walk(prop.value);
+        if (!value || 'test' in value) return;
+        obj[keyValue.value] = value.value;
+      }
+      return obj;
+    }
+    else if (node.type === 'BinaryExpression' || node.type === 'LogicalExpression') {
+      var l = walk(node.left);
+      if (!l) return;
+      var r = walk(node.right);
+      if (!r) return;
+
+      if ('test' in l && 'test' in r)
+        return;
+
+      var op = node.operator;
+      // support right branches only
+      if ('test' in l) {
+        r = r.value;
+        if (op === '==') return { test: l.test, then: l.then == r, else: l.else == r };
+        if (op === '===') return { test: l.test, then: l.then === r, else: l.else === r };
+        if (op === '!=') return { test: l.test, then: l.then != r, else: l.else != r };
+        if (op === '!==') return { test: l.test, then: l.then !== r, else: l.else !== r };
+        if (op === '+') return { test: l.test, then: l.then + r, else: l.else + r };
+        if (op === '-') return { test: l.test, then: l.then - r, else: l.else - r };
+        if (op === '*') return { test: l.test, then: l.then * r, else: l.else * r };
+        if (op === '/') return { test: l.test, then: l.then / r, else: l.else / r };
+        if (op === '%') return { test: l.test, then: l.then % r, else: l.else % r };
+        if (op === '<') return { test: l.test, then: l.then < r, else: l.else < r };
+        if (op === '<=') return { test: l.test, then: l.then <= r, else: l.else <= r };
+        if (op === '>') return { test: l.test, then: l.then > r, else: l.else > r };
+        if (op === '>=') return { test: l.test, then: l.then >= r, else: l.else >= r };
+        if (op === '|') return { test: l.test, then: l.then | r, else: l.else | r };
+        if (op === '&') return { test: l.test, then: l.then & r, else: l.else & r };
+        if (op === '^') return { test: l.test, then: l.then ^ r, else: l.else ^ r };
+        if (op === '&&') return { test: l.test, then: l.then && r, else: l.else && r };
+        if (op === '||') return { test: l.test, then: l.then || r, else: l.else || r };
+      }
+      else if ('test' in r) {
+        l = l.value;
+        if (op === '==') return { test: r.test, then: l == r.then, else: l == r.else };
+        if (op === '===') return { test: r.test, then: l === r.then, else: l === r.else };
+        if (op === '!=') return { test: r.test, then: l != r.then, else: l != r.else };
+        if (op === '!==') return { test: r.test, then: l !== r.then, else: l !== r.else };
+        if (op === '+') return { test: r.test, then: l + r.then, else: l + r.else };
+        if (op === '-') return { test: r.test, then: l - r.then, else: l - r.else };
+        if (op === '*') return { test: r.test, then: l * r.then, else: l * r.else };
+        if (op === '/') return { test: r.test, then: l / r.then, else: l / r.else };
+        if (op === '%') return { test: r.test, then: l % r.then, else: l % r.else };
+        if (op === '<') return { test: r.test, then: l < r.then, else: l < r.else };
+        if (op === '<=') return { test: r.test, then: l <= r.then, else: l <= r.else };
+        if (op === '>') return { test: r.test, then: l > r.then, else: l > r.else };
+        if (op === '>=') return { test: r.test, then: l >= r.then, else: l >= r.else };
+        if (op === '|') return { test: r.test, then: l | r.then, else: l | r.else };
+        if (op === '&') return { test: r.test, then: l & r.then, else: l & r.else };
+        if (op === '^') return { test: r.test, then: l ^ r.then, else: l ^ r.else };
+        if (op === '&&') return { test: r.test, then: l && r.then, else: l && r.else };
+        if (op === '||') return { test: r.test, then: l || r.then, else: l || r.else };
+      }
+      else {
+        l = l.value;
+        r = r.value;
+        if (op === '==') return { value: l == r };
+        if (op === '===') return { value: l === r };
+        if (op === '!=') return { value: l != r };
+        if (op === '!==') return { value: l !== r };
+        if (op === '+') return { value: l + r };
+        if (op === '-') return { value: l - r };
+        if (op === '*') return { value: l * r };
+        if (op === '/') return { value: l / r };
+        if (op === '%') return { value: l % r };
+        if (op === '<') return { value: l < r };
+        if (op === '<=') return { value: l <= r };
+        if (op === '>') return { value: l > r };
+        if (op === '>=') return { value: l >= r };
+        if (op === '|') return { value: l | r };
+        if (op === '&') return { value: l & r };
+        if (op === '^') return { value: l ^ r };
+        if (op === '&&') return { value: l && r };
+        if (op === '||') return { value: l || r };
+      }      
+      return;
+    }
+    else if (node.type === 'Identifier') {
+      if (Object.hasOwnProperty.call(vars, node.name))
+        return { value: vars[node.name] };
+      return;
+    }
+    else if (node.type === 'ThisExpression') {
+      if (Object.hasOwnProperty.call(vars, 'this'))
+        return { value: vars['this'] };
+      return;
+    }
+    else if (node.type === 'CallExpression') {
+      var callee = walk(node.callee);
+      if (!callee || 'test' in callee) return;
+      if (typeof callee.value !== 'function') return;
+      
+      var ctx = node.callee.object && walk(node.callee.object).value || null;
+
+      var args = [];
+      for (var i = 0, l = node.arguments.length; i < l; i++) {
+        var x = walk(node.arguments[i]);
+        if (!x || 'test' in x) return;
+        args.push(x.value);
+      }
+      try {
+        return { value: callee.value.apply(ctx, args) };
+      }
+      catch (e) {
+        return;
+      }
+    }
+    else if (node.type === 'MemberExpression') {
+      var obj = walk(node.object);
+      // do not allow access to methods on Function 
+      if (!obj || 'test' in obj || typeof obj.value === 'function')
+        return;
+      if (node.property.type === 'Identifier')
+        return { value: obj.value[node.property.name] };
+      var prop = walk(node.property);
+      if (!prop || 'test' in prop)
+        return;
+      return { value: obj.value[prop.value] };
+    }
+    else if (node.type === 'ConditionalExpression') {
+      var val = walk(node.test);
+      if (val && 'value' in val)
+        return val.value ? walk(node.consequent) : walk(node.alternate);
+
+      var thenValue = walk(node.consequent);
+      if (!thenValue || 'test' in thenValue)
+        return;
+      var elseValue = walk(node.alternate);
+      if (!elseValue || 'test' in elseValue)
+        return;
+
+      return {
+        test: node.test,
+        then: thenValue.value,
+        else: elseValue.value
+      };
+    }
+    else if (node.type === 'ExpressionStatement') {
+      return walk(node.expression);
+    }
+    else if (node.type === 'ReturnStatement') {
+      return walk(node.argument);
+    }
+    // disabled for now due to a scope bug in the original implementation
+    /* else if (node.type === 'FunctionExpression') {
+      var bodies = node.body.body;
+      
+      // Create a "scope" for our arguments
+      var oldVars = {};
+      Object.keys(vars).forEach(function(element){
+        oldVars[element] = vars[element];
+      });
+
+      node.params.forEach(function(key) {
+        if(key.type == 'Identifier'){
+          vars[key.name] = null;
+        }
+      });
+      for(var i in bodies){
+        if(walk(bodies[i]) === FAIL){
+          return FAIL;
+        }
+      }
+      // restore the vars and scope after we walk
+      vars = oldVars;
+      
+      var keys = Object.keys(vars);
+      var vals = keys.map(function(key) {
+        return vars[key];
+      });
+      return Function(keys.join(', '), 'return ' + unparse(node)).apply(null, vals);
+    } */
+    else if (node.type === 'TemplateLiteral') {
+      var val = { value: '' };
+      for (var i = 0; i < node.expressions.length; i++) {
+        if ('value' in val) {
+          val.value += node.quasis[i].value.cooked;
+        }
+        else {
+          val.then += node.quasis[i].value.cooked;
+          val.else += node.quasis[i].value.cooked;
+        }
+        var exprValue = walk(node.expressions[i]);
+        if (!exprValue)
+          return;
+        if ('value' in exprValue) {
+          if ('value' in val) {
+            val.value += exprValue.value;
+          }
+          else {
+            val.then += exprValue.value;
+            val.else += exprValue.value;
+          }
+        }
+        else {
+          // only support a single branch in a template
+          if ('value' in val === false)
+            return;
+          val = {
+            test: exprValue.test,
+            then: val.value + exprValue.then,
+            else: val.value + exprValue.else
+          };
+        }
+      }
+      if ('value' in val) {
+        val.value += node.quasis[i].value.cooked;
+      }
+      else {
+        val.then += node.quasis[i].value.cooked;
+        val.else += node.quasis[i].value.cooked;
+      }
+      return val;
+    }
+    /* else if (node.type === 'TaggedTemplateExpression') {
+      var tag = walk(node.tag);
+      var quasi = node.quasi;
+      var strings = quasi.quasis.map(walk);
+      var values = quasi.expressions.map(walk);
+      return tag.apply(null, [strings].concat(values));
+    } */
+    return;
+  }
+};

--- a/test/unit/asset-fs-logical/asset1.txt
+++ b/test/unit/asset-fs-logical/asset1.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/unit/asset-fs-logical/asset2.txt
+++ b/test/unit/asset-fs-logical/asset2.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/unit/asset-fs-logical/input.js
+++ b/test/unit/asset-fs-logical/input.js
@@ -1,0 +1,2 @@
+const fs = require('fs');
+console.log(fs.readFileSync(`${__dirname}/asset${unknown ? '1' : '2'}.txt`));

--- a/test/unit/asset-fs-logical/output-coverage.js
+++ b/test/unit/asset-fs-logical/output-coverage.js
@@ -1,0 +1,61 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(3);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 3:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const fs = __webpack_require__(66);
+console.log(fs.readFileSync(unknown ? __dirname + '/asset1.txt' : __dirname + '/asset2.txt'));
+
+
+/***/ }),
+
+/***/ 66:
+/***/ (function(module) {
+
+module.exports = require("fs");
+
+/***/ })
+
+/******/ });

--- a/test/unit/asset-fs-logical/output.js
+++ b/test/unit/asset-fs-logical/output.js
@@ -1,0 +1,61 @@
+module.exports =
+/******/ (function(modules, runtime) { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/
+/******/ 	// the startup function
+/******/ 	function startup() {
+/******/ 		// Load entry module and return exports
+/******/ 		return __webpack_require__(274);
+/******/ 	};
+/******/
+/******/ 	// run startup
+/******/ 	return startup();
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ 66:
+/***/ (function(module) {
+
+module.exports = require("fs");
+
+/***/ }),
+
+/***/ 274:
+/***/ (function(__unusedmodule, __unusedexports, __webpack_require__) {
+
+const fs = __webpack_require__(66);
+console.log(fs.readFileSync(unknown ? __dirname + '/asset1.txt' : __dirname + '/asset2.txt'));
+
+
+/***/ })
+
+/******/ });


### PR DESCRIPTION
This fixes #235 in supporting asset analysis on statements like:

```js
`const filename = `${__dirname}/fonts/Inter-UI-${fontWeight === 'bold' ? 'Bold' : 'Regular'}.woff2`;`.
```

The static evaluator from https://github.com/substack/static-eval is forked and updated to support two branches throughout the analysis paths (any more branches and we go back to an _unknown_ deoptimization state).

Thus even more complex compound cases like `__dirname + '/' + (unknown ? 'a' : 'b') + (__dirname ? 'a' : 'b')` all get supported fine.

Thanks @styfle for the issue, it's these observations and requests that allow the analysis to develop :)