### PR TITLE
Override noEmit option for typescript compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,8 @@ module.exports = (
             options: {
               compiler: eval('__dirname + "/typescript.js"'),
               compilerOptions: {
-                outDir: '//'
+                outDir: '//',
+                noEmit: true
               }
             }
           }]


### PR DESCRIPTION
This provides the `noEmit` override as requested in https://github.com/zeit/ncc/issues/239 to help avoid issues when the TypeScript configuration is in conflict with this setting.