### PR TITLE
Add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@zeit/ncc",
+  "description": "Simple CLI for compiling a Node.js module into a single file, together with all its dependencies, gcc-style.",
   "version": "0.22.3",
   "repository": "zeit/ncc",
   "license": "MIT",


### PR DESCRIPTION
If `description` is missing from package.json, the tools that use it (like `$ npm info` and [npmhub](https://github.com/npmhub/npmhub)) will unsuccessfully try to parse the readme and get nonsense.

### Before

```
$ npm info @zeit/ncc

@zeit/ncc@0.22.3 | MIT | deps: none | versions: 77
[![CI Status](https://github.com/zeit/ncc/workflows/CI/badge.svg)](https://github.com/zeit/ncc/actions?workflow=CI) [![codecov](https://codecov.io/gh/zeit/ncc/branch/master/graph/badge.svg)](https://codecov.io/gh/zeit/ncc)
https://github.com/zeit/ncc#readme

bin: ncc

... etc
```

<img width="599" alt="Screen Shot 2020-06-10 at 19 32 27" src="https://user-images.githubusercontent.com/1402241/84299517-233b2200-ab51-11ea-8989-91eb323f6210.png">


### After


```
$ npm info @zeit/ncc

@zeit/ncc@0.22.3 | MIT | deps: none | versions: 77
Simple CLI for compiling a Node.js module into a single file, together with all its dependencies, gcc-style.
https://github.com/zeit/ncc#readme

bin: ncc

... etc
```