### PR TITLE
Adds support for PnP installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "pdf2json": "^1.1.8",
     "pdfkit": "^0.8.3",
     "pg": "^7.6.1",
+    "pnp-webpack-plugin": "^1.6.4",
     "pug": "^2.0.3",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
@@ -108,8 +109,5 @@
     "vue-server-renderer": "^2.5.17",
     "webpack": "5.0.0-beta.28",
     "when": "^3.7.8"
-  },
-  "dependencies": {
-    "pnp-webpack-plugin": "^1.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -108,5 +108,8 @@
     "vue-server-renderer": "^2.5.17",
     "webpack": "5.0.0-beta.28",
     "when": "^3.7.8"
+  },
+  "dependencies": {
+    "pnp-webpack-plugin": "^1.6.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const shebangRegEx = require('./utils/shebang');
 const nccCacheDir = require("./utils/ncc-cache-dir");
 const LicenseWebpackPlugin = require('license-webpack-plugin').LicenseWebpackPlugin;
+const PnpWebpackPlugin = require('pnp-webpack-plugin');
 const { version: nccVersion } = require('../package.json');
 
 // support glob graceful-fs
@@ -69,7 +70,7 @@ module.exports = (
     existingAssetNames.push(`${filename}.cache`);
     existingAssetNames.push(`${filename}.cache${ext}`);
   }
-  const resolvePlugins = [];
+  const resolvePlugins = [PnpWebpackPlugin];
   // add TsconfigPathsPlugin to support `paths` resolution in tsconfig
   // we need to catch here because the plugin will
   // error if there's no tsconfig in the working directory

--- a/yarn.lock
+++ b/yarn.lock
@@ -11560,6 +11560,13 @@ pngjs@^3.0.0, pngjs@^3.3.3:
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.3.3.tgz#85173703bde3edac8998757b96e5821d0966a21b"
   integrity sha512-1n3Z4p3IOxArEs1VRXnZ/RXdfEniAUS9jb68g58FIXMNkPJeZd+Qh4Uq7/e0LVxAQGos1eIUrqrt4FpjdnEd+Q==
 
+pnp-webpack-plugin@^1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz#c9711ac4dc48a685dabafc86f8b6dd9f8df84149"
+  integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
+  dependencies:
+    ts-pnp "^1.1.6"
+
 pop-iterate@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pop-iterate/-/pop-iterate-1.0.1.tgz#ceacfdab4abf353d7a0f2aaa2c1fc7b3f9413ba3"
@@ -14455,6 +14462,11 @@ ts-loader@^5.3.1:
     loader-utils "^1.0.2"
     micromatch "^3.1.4"
     semver "^5.0.1"
+
+ts-pnp@^1.1.6:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
+  integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
 tsconfig-paths-webpack-plugin@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
This diff simply adds the PnpWebpackPlugin, which lets Webpack resolve dependencies when installed via PnP. Without it, all external dependencies fail to resolve and are silently kept as external requires.