### PR TITLE
Allow passing the webpack target

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "vm2": "^3.6.6",
     "vue": "^2.5.17",
     "vue-server-renderer": "^2.5.17",
+    "web-vitals": "^0.2.4",
     "webpack": "5.2.0",
     "when": "^3.7.8"
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -35,7 +35,7 @@ Options:
   --v8-cache               Emit a build using the v8 compile cache
   --license [file]         Adds a file containing licensing information to the output
   --stats-out [file]       Emit webpack stats as json to the specified output file
-  --webpack-target         What build target to use for webpack (default: node)
+  --target                  What build target to use for webpack (default: es6)
 `;
 
 // support an API mode for CLI testing
@@ -148,7 +148,7 @@ async function runCmd (argv, stdout, stderr) {
       "-t": "--transpile-only",
       "--license": String,
       "--stats-out": String,
-      "--webpack-target": String
+      "--target": String
     }, {
       permissive: false,
       argv
@@ -241,9 +241,7 @@ async function runCmd (argv, stdout, stderr) {
           transpileOnly: args["--transpile-only"],
           license: args["--license"],
           quiet,
-          target: args["--webpack-target"]
-            ? args["--webpack-target"].split(',')
-            : undefined
+          target: args["--target"]
         }
       );
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -35,6 +35,7 @@ Options:
   --v8-cache               Emit a build using the v8 compile cache
   --license [file]         Adds a file containing licensing information to the output
   --stats-out [file]       Emit webpack stats as json to the specified output file
+  --webpack-target         What build target to use for webpack (default: node)
 `;
 
 // support an API mode for CLI testing
@@ -147,6 +148,7 @@ async function runCmd (argv, stdout, stderr) {
       "-t": "--transpile-only",
       "--license": String,
       "--stats-out": String,
+      "--webpack-target": String
     }, {
       permissive: false,
       argv
@@ -238,7 +240,10 @@ async function runCmd (argv, stdout, stderr) {
           v8cache: args["--v8-cache"],
           transpileOnly: args["--transpile-only"],
           license: args["--license"],
-          quiet
+          quiet,
+          target: args["--webpack-target"]
+            ? args["--webpack-target"].split(',')
+            : undefined
         }
       );
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,8 @@ module.exports = (
     quiet = false,
     debugLog = false,
     transpileOnly = false,
-    license = ''
+    license = '',
+    target
   } = {}
 ) => {
   process.env.__NCC_OPTS = JSON.stringify({
@@ -187,7 +188,7 @@ module.exports = (
     },
     devtool: sourceMap ? "cheap-module-source-map" : false,
     mode: "production",
-    target: "node",
+    target: target || "node",
     stats: {
       logging: 'error'
     },

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,11 @@ module.exports = (
     console.log(`ncc: Version ${nccVersion}`);
     console.log(`ncc: Compiling file ${filename}`);
   }
+
+  if (target && !target.startsWith('es')) {
+    throw new Error(`Invalid "target" value provided ${target}, value must be es version e.g. es5`)
+  }
+
   const resolvedEntry = resolve.sync(entry);
   process.env.TYPESCRIPT_LOOKUP_PATH = resolvedEntry;
   const shebangMatch = fs.readFileSync(resolvedEntry).toString().match(shebangRegEx);
@@ -188,7 +193,7 @@ module.exports = (
     },
     devtool: sourceMap ? "cheap-module-source-map" : false,
     mode: "production",
-    target: target || "node",
+    target: target ? ["node", target] : "node",
     stats: {
       logging: 'error'
     },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,6 @@
+const os = require("os");
 const fs = require("fs");
+const path = require("path");
 const { fork } = require("child_process");
 const coverage = global.coverage;
 const ncc = coverage ? require("../src/index") : require("../");
@@ -106,24 +108,25 @@ else {
   nccRun = require(__dirname + "/../dist/ncc/cli.js");
 }
 
+const { Writable } = require('stream');
+
+class StoreStream extends Writable {
+  constructor (options) {
+    super(options);
+    this.data = [];
+  }
+  _write(chunk, encoding, callback) {
+    this.data.push(chunk);
+    callback();
+  }
+}
+
 for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
   // ignore e.g.: `.json` files
   if (!/\.(mjs|tsx?|js)$/.test(integrationTest)) continue;
 
   // disabled pending https://github.com/zeit/ncc/issues/141
   if (integrationTest.endsWith('loopback.js')) continue;
-
-  const { Writable } = require('stream');
-  class StoreStream extends Writable {
-    constructor (options) {
-      super(options);
-      this.data = [];
-    }
-    _write(chunk, encoding, callback) {
-      this.data.push(chunk);
-      callback();
-    }
-  }
 
   it(`should execute "ncc run ${integrationTest}"`, async () => {
     let expectedStdout;
@@ -155,6 +158,41 @@ for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
     }
   });
 }
+
+it(`should execute "ncc build web-vitals" with target config`, async () => {
+  if (global.gc) global.gc();
+  const stdout = new StoreStream();
+  const stderr = new StoreStream();
+
+  const tmpOut = path.join(os.tmpdir(), `ncc_${Math.random()}`)
+
+  try {
+    await nccRun(["build", "-o", tmpOut, "--webpack-target", "node,es5", require.resolve('web-vitals/dist/web-vitals.es5.min.js')], stdout, stderr);
+  }
+  catch (e) {
+    if (e.silent) {
+      let lastErr = stderr.data[stderr.data.length - 1];
+      if (lastErr)
+        throw new Error(lastErr);
+      else
+        throw new Error('Process exited with code ' + e.exitCode);
+    }
+    throw e;
+  }
+
+  const outFile = path.join(tmpOut, 'index.js')
+  const output = fs.readFileSync(outFile, 'utf8')
+
+  // cleanup tmp output
+  fs.unlinkSync(outFile)
+  fs.rmdirSync(tmpOut)
+
+  console.log(output)
+
+  expect(output).toContain('function')
+  // make sure es6 wrapper wasn't used
+  expect(output).not.toContain('=>')
+});
 
 // remove me when node.js makes this the default behavior
 process.on("unhandledRejection", e => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -167,7 +167,7 @@ it(`should execute "ncc build web-vitals" with target config`, async () => {
   const tmpOut = path.join(os.tmpdir(), `ncc_${Math.random()}`)
 
   try {
-    await nccRun(["build", "-o", tmpOut, "--webpack-target", "node,es5", require.resolve('web-vitals/dist/web-vitals.es5.min.js')], stdout, stderr);
+    await nccRun(["build", "-o", tmpOut, "--target", "es5", require.resolve('web-vitals/dist/web-vitals.es5.min.js')], stdout, stderr);
   }
   catch (e) {
     if (e.silent) {
@@ -186,8 +186,6 @@ it(`should execute "ncc build web-vitals" with target config`, async () => {
   // cleanup tmp output
   fs.unlinkSync(outFile)
   fs.rmdirSync(tmpOut)
-
-  console.log(output)
 
   expect(output).toContain('function')
   // make sure es6 wrapper wasn't used

--- a/yarn.lock
+++ b/yarn.lock
@@ -15086,6 +15086,11 @@ weak-map@^1.0.5:
   resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.5.tgz#79691584d98607f5070bd3b70a40e6bb22e401eb"
   integrity sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes=
 
+web-vitals@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.4.tgz#ec3df43c834a207fd7cdefd732b2987896e08511"
+  integrity sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/next.js/pull/18873 to allow us to pass a target of `node,es5` to `ncc` since `webpack` defaults to using `es6` code for `node` which breaks ie11 compatibility  