### PR TITLE
add TypeScript module

### DIFF
--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -11,6 +11,7 @@
     "chalk": "^2.4.1"
   },
   "devDependencies": {
-    "@vercel/ncc": "latest"
+    "@vercel/ncc": "latest",
+     "typescript": "^4.1.2"
   }
 }


### PR DESCRIPTION
if you don't add the typescript module then the following error message will appear

```
Error: Could not load TypeScript compiler with NPM package name `/Users/styfle/Desktop/ncc-ts/node_modules/@vercel/ncc/dist/ncc/typescript.js`. Are you sure it is correctly installed?
```