### PR TITLE
Ensure separate asset compilation states in subbuilds

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@sentry/node": "^4.3.0",
     "@slack/web-api": "^5.13.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@vercel/webpack-asset-relocator-loader": "github:vercel/webpack-asset-relocator-loader#subbuild-compilations",
+    "@vercel/webpack-asset-relocator-loader": "github:vercel/webpack-asset-relocator-loader#master",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@sentry/node": "^4.3.0",
     "@slack/web-api": "^5.13.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@vercel/webpack-asset-relocator-loader": "0.9.1",
+    "@vercel/webpack-asset-relocator-loader": "github:vercel/webpack-asset-relocator-loader#subbuild-compilations",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@sentry/node": "^4.3.0",
     "@slack/web-api": "^5.13.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@vercel/webpack-asset-relocator-loader": "github:vercel/webpack-asset-relocator-loader#master",
+    "@vercel/webpack-asset-relocator-loader": "1.0.0",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -54,8 +54,9 @@ async function main() {
     {
       filename: "ts-loader.js",
       minify,
-      v8cache: true
-    }
+      v8cache: true,
+      noAssetBuilds: true
+    },
   );
   checkUnknownAssets('ts-loader', Object.keys(tsLoaderAssets).filter(asset => !asset.startsWith('lib/') && !asset.startsWith('typescript/lib')));
 

--- a/src/index.js
+++ b/src/index.js
@@ -470,7 +470,7 @@ function ncc (
             noAssetBuilds: true,
             v8cache,
             filterAssetBase,
-            existingAssetNames: [...assetNames, `${filename}${ext === '.cjs' ? '.js' : ''}`],
+            existingAssetNames: [...Object.keys(assets), `${filename}${ext === '.cjs' ? '.js' : ''}`],
             quiet,
             debugLog,
             transpileOnly,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,7 +77,7 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
   });
 }
 for (const cliTest of eval(fs.readFileSync(__dirname + "/cli.js").toString())) {
-  it(`should execute "ncc ${(cliTest.args || []).join(" ")}"`, async () => {
+  it.skip(`should execute "ncc ${(cliTest.args || []).join(" ")}"`, async () => {
     const ps = fork(__dirname + (coverage ? "/../src/cli.js" : "/../dist/ncc/cli.js"), cliTest.args || [], {
       stdio: "pipe"
     });
@@ -134,7 +134,7 @@ for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
   // disabled pending https://github.com/zeit/ncc/issues/141
   if (integrationTest.endsWith('loopback.js')) continue;
 
-  it(`should execute "ncc run ${integrationTest}"`, async () => {
+  it.skip(`should execute "ncc run ${integrationTest}"`, async () => {
     let expectedStdout;
     try {
       expectedStdout = fs.readFileSync(`${__dirname}/integration/${integrationTest}.stdout`).toString();
@@ -165,7 +165,7 @@ for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
   });
 }
 
-it(`should execute "ncc build web-vitals" with target config`, async () => {
+it.skip(`should execute "ncc build web-vitals" with target config`, async () => {
   if (global.gc) global.gc();
   const stdout = new StoreStream();
   const stderr = new StoreStream();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,7 +77,7 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
   });
 }
 for (const cliTest of eval(fs.readFileSync(__dirname + "/cli.js").toString())) {
-  it.skip(`should execute "ncc ${(cliTest.args || []).join(" ")}"`, async () => {
+  it(`should execute "ncc ${(cliTest.args || []).join(" ")}"`, async () => {
     const ps = fork(__dirname + (coverage ? "/../src/cli.js" : "/../dist/ncc/cli.js"), cliTest.args || [], {
       stdio: "pipe"
     });
@@ -134,7 +134,7 @@ for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
   // disabled pending https://github.com/zeit/ncc/issues/141
   if (integrationTest.endsWith('loopback.js')) continue;
 
-  it.skip(`should execute "ncc run ${integrationTest}"`, async () => {
+  it(`should execute "ncc run ${integrationTest}"`, async () => {
     let expectedStdout;
     try {
       expectedStdout = fs.readFileSync(`${__dirname}/integration/${integrationTest}.stdout`).toString();
@@ -165,7 +165,7 @@ for (const integrationTest of fs.readdirSync(__dirname + "/integration")) {
   });
 }
 
-it.skip(`should execute "ncc build web-vitals" with target config`, async () => {
+it(`should execute "ncc build web-vitals" with target config`, async () => {
   if (global.gc) global.gc();
   const stdout = new StoreStream();
   const stderr = new StoreStream();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,9 +1902,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vercel/webpack-asset-relocator-loader@github:vercel/webpack-asset-relocator-loader#master":
-  version "0.9.1"
-  resolved "https://codeload.github.com/vercel/webpack-asset-relocator-loader/tar.gz/be1bb7978e889638576ffd5ce229491c6b30c0ee"
+"@vercel/webpack-asset-relocator-loader@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.0.0.tgz#cc3cae3b3cc8f3f631552e1ca97e566f597d5e5b"
+  integrity sha512-JZGVEFBOR0I7ccwewsWSSOB/ke6wYV4e09qQHtTBLTe/zgWrsjes7SX1Xt9M1UgiMTkhZ/0jyJpdxEqrpaYRMA==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,10 +1902,9 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vercel/webpack-asset-relocator-loader@0.9.1":
+"@vercel/webpack-asset-relocator-loader@github:vercel/webpack-asset-relocator-loader#master":
   version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.9.1.tgz#b9cd56e7b7de002830410aca708b76eea930a2cd"
-  integrity sha512-TJXZZa94a3mDB0jdHCDFaWzrFGwsNqpYNqqKeUieznpToN//9XDjQgwkgpvAhG04wwGBFIPvBBfZZdBsvGhLqQ==
+  resolved "https://codeload.github.com/vercel/webpack-asset-relocator-loader/tar.gz/be1bb7978e889638576ffd5ce229491c6b30c0ee"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"


### PR DESCRIPTION
This uses the new feature of webpack-asset-relocator-loader in https://github.com/vercel/webpack-asset-relocator-loader/pull/102.

This gets the build of Piscina to work properly with the worker load as a separate build but there may yet be test failures on this branch, still verifying here further.