### PR TITLE
Enable minification for sourcemap-register.js

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -62,7 +62,7 @@ async function main() {
 
   const { code: sourcemapSupport, assets: sourcemapAssets } = await ncc(
     require.resolve("source-map-support/register"),
-    { filename: "sourcemap-register.js", minify: true, v8cache: true }
+    { filename: "sourcemap-register.js", minify, v8cache: true }
   );
   checkUnknownAssets('source-map-support/register', Object.keys(sourcemapAssets));
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -62,7 +62,7 @@ async function main() {
 
   const { code: sourcemapSupport, assets: sourcemapAssets } = await ncc(
     require.resolve("source-map-support/register"),
-    { filename: "sourcemap-register.js", minfiy: true, v8cache: true }
+    { filename: "sourcemap-register.js", minify: true, v8cache: true }
   );
   checkUnknownAssets('source-map-support/register', Object.keys(sourcemapAssets));
 


### PR DESCRIPTION
File `scripts/build.js` contains invalid configuration for `ncc`.
Most likely it does not do what was expected. After fixed, the `/dist/ncc/sourcemap-register.js.cache.js` file becomes minified. And its weight is reduced by `86kb`.

**File:** `/dist/ncc/sourcemap-register.js.cache.js`
**Original size:** `127kb`
**Fixed:** `41kb`