### PR TITLE
Avoid __webpack_require__ conflicts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -444,6 +444,11 @@ function ncc (
         map.mappings = ";" + map.mappings;
     }
 
+    // __webpack_require__ can conflict with webpack injections in module scopes
+    // to avoid this without recomputing the source map we replace it with an
+    // identical length identifier
+    code = code.replace(/__webpack_require__/g, '__nccwpck_require__');
+
     // for each .js / .mjs / .cjs file in the asset list, build that file with ncc itself
     if (!noAssetBuilds) {
       const compilation = compilationStack[compilationStack.length - 1];

--- a/src/index.js
+++ b/src/index.js
@@ -447,7 +447,8 @@ function ncc (
     // __webpack_require__ can conflict with webpack injections in module scopes
     // to avoid this without recomputing the source map we replace it with an
     // identical length identifier
-    code = code.replace(/__webpack_require__/g, '__nccwpck_require__');
+    if (code.indexOf('"__webpack_require__"') === -1)
+      code = code.replace(/__webpack_require__/g, '__nccwpck_require__');
 
     // for each .js / .mjs / .cjs file in the asset list, build that file with ncc itself
     if (!noAssetBuilds) {

--- a/test/unit/bundle-subasset/output-coverage.js
+++ b/test/unit/bundle-subasset/output-coverage.js
@@ -4,20 +4,20 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 929:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
-__webpack_require__.r(__webpack_exports__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(622);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(622);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
 
 
-const file = __webpack_require__.ab + "pi-bridge.js";
+const file = __nccwpck_require__.ab + "pi-bridge.js";
 
 const obscureRequire = eval(`function obscureRequire (file) {
     require(file);
 }`);
 
-console.log(obscureRequire(__webpack_require__.ab + "pi-bridge.js"));
+console.log(obscureRequire(__nccwpck_require__.ab + "pi-bridge.js"));
 
 
 /***/ }),
@@ -35,7 +35,7 @@ module.exports = require("path");
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -50,7 +50,7 @@ module.exports = require("path");
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -64,11 +64,11 @@ module.exports = require("path");
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
-/******/ 		__webpack_require__.n = (module) => {
+/******/ 		__nccwpck_require__.n = (module) => {
 /******/ 			var getter = module && module.__esModule ?
 /******/ 				() => module['default'] :
 /******/ 				() => module;
-/******/ 			__webpack_require__.d(getter, { a: getter });
+/******/ 			__nccwpck_require__.d(getter, { a: getter });
 /******/ 			return getter;
 /******/ 		};
 /******/ 	})();
@@ -76,9 +76,9 @@ module.exports = require("path");
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
-/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
 /******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
 /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
 /******/ 				}
 /******/ 			}
@@ -87,13 +87,13 @@ module.exports = require("path");
 /******/ 	
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
-/******/ 		__webpack_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
+/******/ 		__nccwpck_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 /******/ 	})();
 /******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
-/******/ 		__webpack_require__.r = (exports) => {
+/******/ 		__nccwpck_require__.r = (exports) => {
 /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
 /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 			}
@@ -103,10 +103,10 @@ module.exports = require("path");
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(929);
+/******/ 	return __nccwpck_require__(929);
 /******/ })()
 ;

--- a/test/unit/bundle-subasset/output.js
+++ b/test/unit/bundle-subasset/output.js
@@ -4,20 +4,20 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 743:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
-__webpack_require__.r(__webpack_exports__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(622);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(622);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
 
 
-const file = __webpack_require__.ab + "pi-bridge.js";
+const file = __nccwpck_require__.ab + "pi-bridge.js";
 
 const obscureRequire = eval(`function obscureRequire (file) {
     require(file);
 }`);
 
-console.log(obscureRequire(__webpack_require__.ab + "pi-bridge.js"));
+console.log(obscureRequire(__nccwpck_require__.ab + "pi-bridge.js"));
 
 
 /***/ }),
@@ -35,7 +35,7 @@ module.exports = require("path");
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -50,7 +50,7 @@ module.exports = require("path");
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -64,11 +64,11 @@ module.exports = require("path");
 /******/ 	/* webpack/runtime/compat get default export */
 /******/ 	(() => {
 /******/ 		// getDefaultExport function for compatibility with non-harmony modules
-/******/ 		__webpack_require__.n = (module) => {
+/******/ 		__nccwpck_require__.n = (module) => {
 /******/ 			var getter = module && module.__esModule ?
 /******/ 				() => module['default'] :
 /******/ 				() => module;
-/******/ 			__webpack_require__.d(getter, { a: getter });
+/******/ 			__nccwpck_require__.d(getter, { a: getter });
 /******/ 			return getter;
 /******/ 		};
 /******/ 	})();
@@ -76,9 +76,9 @@ module.exports = require("path");
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
-/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
 /******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
 /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
 /******/ 				}
 /******/ 			}
@@ -87,13 +87,13 @@ module.exports = require("path");
 /******/ 	
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
-/******/ 		__webpack_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
+/******/ 		__nccwpck_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 /******/ 	})();
 /******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
-/******/ 		__webpack_require__.r = (exports) => {
+/******/ 		__nccwpck_require__.r = (exports) => {
 /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
 /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 			}
@@ -103,10 +103,10 @@ module.exports = require("path");
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(743);
+/******/ 	return __nccwpck_require__(743);
 /******/ })()
 ;

--- a/test/unit/bundle-subasset2/output-coverage.js
+++ b/test/unit/bundle-subasset2/output-coverage.js
@@ -4,7 +4,7 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 448:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -43,10 +43,10 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 exports.__esModule = true;
-var piscina_1 = __webpack_require__(409);
-var path = __webpack_require__(622);
+var piscina_1 = __nccwpck_require__(409);
+var path = __nccwpck_require__(622);
 var piscina = new piscina_1["default"]({
-    filename: __webpack_require__.ab + "pi-bridge.js"
+    filename: __nccwpck_require__.ab + "pi-bridge.js"
 });
 (function () {
     return __awaiter(this, void 0, void 0, function () {
@@ -86,7 +86,7 @@ module.exports = require("piscina");
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -101,7 +101,7 @@ module.exports = require("piscina");
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -114,10 +114,10 @@ module.exports = require("piscina");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(448);
+/******/ 	return __nccwpck_require__(448);
 /******/ })()
 ;

--- a/test/unit/bundle-subasset2/output.js
+++ b/test/unit/bundle-subasset2/output.js
@@ -4,7 +4,7 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 886:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -43,10 +43,10 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 exports.__esModule = true;
-var piscina_1 = __webpack_require__(409);
-var path = __webpack_require__(622);
+var piscina_1 = __nccwpck_require__(409);
+var path = __nccwpck_require__(622);
 var piscina = new piscina_1["default"]({
-    filename: __webpack_require__.ab + "pi-bridge.js"
+    filename: __nccwpck_require__.ab + "pi-bridge.js"
 });
 (function () {
     return __awaiter(this, void 0, void 0, function () {
@@ -86,7 +86,7 @@ module.exports = require("piscina");
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -101,7 +101,7 @@ module.exports = require("piscina");
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -114,10 +114,10 @@ module.exports = require("piscina");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(886);
+/******/ 	return __nccwpck_require__(886);
 /******/ })()
 ;

--- a/test/unit/externals/output-coverage.js
+++ b/test/unit/externals/output-coverage.js
@@ -3,9 +3,9 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 157:
-/***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const external = __webpack_require__(306);
+const external = __nccwpck_require__(306);
 
 console.log(external);
 
@@ -26,7 +26,7 @@ module.exports = require("externalmapped");
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -41,7 +41,7 @@ module.exports = require("externalmapped");
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -54,10 +54,10 @@ module.exports = require("externalmapped");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(157);
+/******/ 	return __nccwpck_require__(157);
 /******/ })()
 ;

--- a/test/unit/externals/output.js
+++ b/test/unit/externals/output.js
@@ -3,9 +3,9 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 369:
-/***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const external = __webpack_require__(306);
+const external = __nccwpck_require__(306);
 
 console.log(external);
 
@@ -26,7 +26,7 @@ module.exports = require("externalmapped");
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -41,7 +41,7 @@ module.exports = require("externalmapped");
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -54,10 +54,10 @@ module.exports = require("externalmapped");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(369);
+/******/ 	return __nccwpck_require__(369);
 /******/ })()
 ;

--- a/test/unit/minify/output-coverage.js
+++ b/test/unit/minify/output-coverage.js
@@ -1,2 +1,2 @@
-module.exports=(()=>{var e={894:(e,r)=>{const _="qux";r.foobar=_}};var r={};function __webpack_require__(_){if(r[_]){return r[_].exports}var a=r[_]={exports:{}};var t=true;try{e[_](a,a.exports,__webpack_require__);t=false}finally{if(t)delete r[_]}return a.exports}__webpack_require__.ab=__dirname+"/";return __webpack_require__(894)})();
+module.exports=(()=>{var e={894:(e,r)=>{const _="qux";r.foobar=_}};var r={};function __nccwpck_require__(_){if(r[_]){return r[_].exports}var a=r[_]={exports:{}};var t=true;try{e[_](a,a.exports,__nccwpck_require__);t=false}finally{if(t)delete r[_]}return a.exports}__nccwpck_require__.ab=__dirname+"/";return __nccwpck_require__(894)})();
 //# sourceMappingURL=index.js.map

--- a/test/unit/minify/output.js
+++ b/test/unit/minify/output.js
@@ -1,2 +1,2 @@
-module.exports=(()=>{var e={657:(e,r)=>{const _="qux";r.foobar=_}};var r={};function __webpack_require__(_){if(r[_]){return r[_].exports}var a=r[_]={exports:{}};var t=true;try{e[_](a,a.exports,__webpack_require__);t=false}finally{if(t)delete r[_]}return a.exports}__webpack_require__.ab=__dirname+"/";return __webpack_require__(657)})();
+module.exports=(()=>{var e={657:(e,r)=>{const _="qux";r.foobar=_}};var r={};function __nccwpck_require__(_){if(r[_]){return r[_].exports}var a=r[_]={exports:{}};var t=true;try{e[_](a,a.exports,__nccwpck_require__);t=false}finally{if(t)delete r[_]}return a.exports}__nccwpck_require__.ab=__dirname+"/";return __nccwpck_require__(657)})();
 //# sourceMappingURL=index.js.map

--- a/test/unit/runtime-notfound/output-coverage.js
+++ b/test/unit/runtime-notfound/output-coverage.js
@@ -3,10 +3,10 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 159:
-/***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, __unused_webpack_exports, __nccwpck_require__) => {
 
-__webpack_require__(464);
-__webpack_require__(497);
+__nccwpck_require__(464);
+__nccwpck_require__(497);
 
 /***/ }),
 
@@ -32,7 +32,7 @@ module.exports = eval("require")("./not-found.js");
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -47,7 +47,7 @@ module.exports = eval("require")("./not-found.js");
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -60,10 +60,10 @@ module.exports = eval("require")("./not-found.js");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(159);
+/******/ 	return __nccwpck_require__(159);
 /******/ })()
 ;

--- a/test/unit/runtime-notfound/output.js
+++ b/test/unit/runtime-notfound/output.js
@@ -3,10 +3,10 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 44:
-/***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, __unused_webpack_exports, __nccwpck_require__) => {
 
-__webpack_require__(367);
-__webpack_require__(695);
+__nccwpck_require__(367);
+__nccwpck_require__(695);
 
 /***/ }),
 
@@ -32,7 +32,7 @@ module.exports = eval("require")("./not-found.js");
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -47,7 +47,7 @@ module.exports = eval("require")("./not-found.js");
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -60,10 +60,10 @@ module.exports = eval("require")("./not-found.js");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(44);
+/******/ 	return __nccwpck_require__(44);
 /******/ })()
 ;

--- a/test/unit/shebang/output-coverage.js
+++ b/test/unit/shebang/output-coverage.js
@@ -16,7 +16,7 @@ module.exports = 'asdf';
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -31,7 +31,7 @@ module.exports = 'asdf';
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -44,10 +44,10 @@ module.exports = 'asdf';
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(937);
+/******/ 	return __nccwpck_require__(937);
 /******/ })()
 ;

--- a/test/unit/shebang/output.js
+++ b/test/unit/shebang/output.js
@@ -16,7 +16,7 @@ module.exports = 'asdf';
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -31,7 +31,7 @@ module.exports = 'asdf';
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -44,10 +44,10 @@ module.exports = 'asdf';
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(971);
+/******/ 	return __nccwpck_require__(971);
 /******/ })()
 ;

--- a/test/unit/ts-decl/output-coverage.js
+++ b/test/unit/ts-decl/output-coverage.js
@@ -4,14 +4,14 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 345:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   "__esModule": () => /* reexport safe */ _test_ts__WEBPACK_IMPORTED_MODULE_0__.X,
 /* harmony export */   "test": () => /* reexport safe */ _test_ts__WEBPACK_IMPORTED_MODULE_0__.B
 /* harmony export */ });
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(563);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(563);
 
 
 
@@ -36,7 +36,7 @@ exports.B = test;
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -51,7 +51,7 @@ exports.B = test;
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -65,9 +65,9 @@ exports.B = test;
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
-/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
 /******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
 /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
 /******/ 				}
 /******/ 			}
@@ -76,13 +76,13 @@ exports.B = test;
 /******/ 	
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
-/******/ 		__webpack_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
+/******/ 		__nccwpck_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 /******/ 	})();
 /******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
-/******/ 		__webpack_require__.r = (exports) => {
+/******/ 		__nccwpck_require__.r = (exports) => {
 /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
 /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 			}
@@ -92,10 +92,10 @@ exports.B = test;
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(345);
+/******/ 	return __nccwpck_require__(345);
 /******/ })()
 ;

--- a/test/unit/ts-decl/output.js
+++ b/test/unit/ts-decl/output.js
@@ -4,14 +4,14 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 582:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   "__esModule": () => /* reexport safe */ _test_ts__WEBPACK_IMPORTED_MODULE_0__.X,
 /* harmony export */   "test": () => /* reexport safe */ _test_ts__WEBPACK_IMPORTED_MODULE_0__.B
 /* harmony export */ });
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(250);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(250);
 
 
 
@@ -36,7 +36,7 @@ exports.B = test;
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -51,7 +51,7 @@ exports.B = test;
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -65,9 +65,9 @@ exports.B = test;
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
-/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
 /******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
 /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
 /******/ 				}
 /******/ 			}
@@ -76,13 +76,13 @@ exports.B = test;
 /******/ 	
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
-/******/ 		__webpack_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
+/******/ 		__nccwpck_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 /******/ 	})();
 /******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
-/******/ 		__webpack_require__.r = (exports) => {
+/******/ 		__nccwpck_require__.r = (exports) => {
 /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
 /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 			}
@@ -92,10 +92,10 @@ exports.B = test;
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(582);
+/******/ 	return __nccwpck_require__(582);
 /******/ })()
 ;

--- a/test/unit/ts-exts/output-coverage.js
+++ b/test/unit/ts-exts/output-coverage.js
@@ -14,22 +14,22 @@ exports.default = {};
 /***/ }),
 
 /***/ 43:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
 exports.__esModule = true;
-var dep_dep_js_1 = __webpack_require__(119);
+var dep_dep_js_1 = __nccwpck_require__(119);
 exports.default = dep_dep_js_1["default"];
 
 
 /***/ }),
 
 /***/ 368:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
 exports.__esModule = true;
-var dep_js_1 = __webpack_require__(43);
+var dep_js_1 = __nccwpck_require__(43);
 console.log(dep_js_1["default"]);
 
 
@@ -41,7 +41,7 @@ console.log(dep_js_1["default"]);
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -56,7 +56,7 @@ console.log(dep_js_1["default"]);
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -69,10 +69,10 @@ console.log(dep_js_1["default"]);
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(368);
+/******/ 	return __nccwpck_require__(368);
 /******/ })()
 ;

--- a/test/unit/ts-exts/output.js
+++ b/test/unit/ts-exts/output.js
@@ -14,22 +14,22 @@ exports.default = {};
 /***/ }),
 
 /***/ 975:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
 exports.__esModule = true;
-var dep_dep_js_1 = __webpack_require__(668);
+var dep_dep_js_1 = __nccwpck_require__(668);
 exports.default = dep_dep_js_1["default"];
 
 
 /***/ }),
 
 /***/ 578:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
 exports.__esModule = true;
-var dep_js_1 = __webpack_require__(975);
+var dep_js_1 = __nccwpck_require__(975);
 console.log(dep_js_1["default"]);
 
 
@@ -41,7 +41,7 @@ console.log(dep_js_1["default"]);
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -56,7 +56,7 @@ console.log(dep_js_1["default"]);
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -69,10 +69,10 @@ console.log(dep_js_1["default"]);
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(578);
+/******/ 	return __nccwpck_require__(578);
 /******/ })()
 ;

--- a/test/unit/tsconfig-paths-allowjs/output-coverage.js
+++ b/test/unit/tsconfig-paths-allowjs/output-coverage.js
@@ -4,10 +4,10 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 306:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => __WEBPACK_DEFAULT_EXPORT__
 /* harmony export */ });
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({});
@@ -16,11 +16,11 @@ __webpack_require__.r(__webpack_exports__);
 /***/ }),
 
 /***/ 439:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(306);
+var _module_1 = __nccwpck_require__(306);
 console.log(_module_1["default"]);
 
 
@@ -32,7 +32,7 @@ console.log(_module_1["default"]);
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -47,7 +47,7 @@ console.log(_module_1["default"]);
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -61,9 +61,9 @@ console.log(_module_1["default"]);
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
-/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
 /******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
 /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
 /******/ 				}
 /******/ 			}
@@ -72,13 +72,13 @@ console.log(_module_1["default"]);
 /******/ 	
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
-/******/ 		__webpack_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
+/******/ 		__nccwpck_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 /******/ 	})();
 /******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
-/******/ 		__webpack_require__.r = (exports) => {
+/******/ 		__nccwpck_require__.r = (exports) => {
 /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
 /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 			}
@@ -88,10 +88,10 @@ console.log(_module_1["default"]);
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(439);
+/******/ 	return __nccwpck_require__(439);
 /******/ })()
 ;

--- a/test/unit/tsconfig-paths-allowjs/output.js
+++ b/test/unit/tsconfig-paths-allowjs/output.js
@@ -3,12 +3,12 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 468:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(17);
+var _module_1 = __nccwpck_require__(17);
 console.log(_module_1["default"]);
 
 
@@ -28,7 +28,7 @@ module.exports = eval("require")("@module");
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -43,7 +43,7 @@ module.exports = eval("require")("@module");
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -56,10 +56,10 @@ module.exports = eval("require")("@module");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(468);
+/******/ 	return __nccwpck_require__(468);
 /******/ })()
 ;

--- a/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
@@ -4,11 +4,11 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 777:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(775);
+var _module_1 = __nccwpck_require__(775);
 console.log(_module_1["default"]);
 
 
@@ -30,7 +30,7 @@ exports.default = {};
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -45,7 +45,7 @@ exports.default = {};
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -58,10 +58,10 @@ exports.default = {};
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(777);
+/******/ 	return __nccwpck_require__(777);
 /******/ })()
 ;

--- a/test/unit/tsconfig-paths-conflicting-external/output.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output.js
@@ -3,12 +3,12 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 213:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(17);
+var _module_1 = __nccwpck_require__(17);
 console.log(_module_1["default"]);
 
 
@@ -28,7 +28,7 @@ module.exports = eval("require")("@module");
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -43,7 +43,7 @@ module.exports = eval("require")("@module");
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -56,10 +56,10 @@ module.exports = eval("require")("@module");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(213);
+/******/ 	return __nccwpck_require__(213);
 /******/ })()
 ;

--- a/test/unit/tsconfig-paths/output-coverage.js
+++ b/test/unit/tsconfig-paths/output-coverage.js
@@ -4,11 +4,11 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 532:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(520);
+var _module_1 = __nccwpck_require__(520);
 console.log(_module_1["default"]);
 
 
@@ -30,7 +30,7 @@ exports.default = {};
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -45,7 +45,7 @@ exports.default = {};
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -58,10 +58,10 @@ exports.default = {};
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(532);
+/******/ 	return __nccwpck_require__(532);
 /******/ })()
 ;

--- a/test/unit/tsconfig-paths/output.js
+++ b/test/unit/tsconfig-paths/output.js
@@ -3,12 +3,12 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 879:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 exports.__esModule = true;
-var _module_1 = __webpack_require__(17);
+var _module_1 = __nccwpck_require__(17);
 console.log(_module_1["default"]);
 
 
@@ -28,7 +28,7 @@ module.exports = eval("require")("@module");
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -43,7 +43,7 @@ module.exports = eval("require")("@module");
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -56,10 +56,10 @@ module.exports = eval("require")("@module");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(879);
+/******/ 	return __nccwpck_require__(879);
 /******/ })()
 ;


### PR DESCRIPTION
This implements a very simple fix for `__webpack_require__` scoping conflicts due to webpack bug https://github.com/webpack/webpack/issues/1054, by simply replacing this identifier with a ncc unique identifier such that ncc bundles can be bundled with webpack without conflict.

I can confirm this approach resolves https://github.com/vercel/ncc/issues/589.

//cc @sokra 