### PR TITLE
fix: skip typechecking on sub-builds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -488,7 +488,8 @@ function ncc (
           existingAssetNames,
           quiet,
           debugLog,
-          transpileOnly,
+          // don't re-run type checking on a sub-build, as it is a waste of CPU
+          transpileOnly: true,
           license,
           target
         });


### PR DESCRIPTION
This PR is a performance optimization that skips type checking on a sub-asset build. This would've already been performed by the parent process.