### PR TITLE
update to webpack-asset-relocator@1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@sentry/node": "^4.3.0",
     "@slack/web-api": "^5.13.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@vercel/webpack-asset-relocator-loader": "1.2.0",
+    "@vercel/webpack-asset-relocator-loader": "1.2.1",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@sentry/node": "^4.3.0",
     "@slack/web-api": "^5.13.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@vercel/webpack-asset-relocator-loader": "1.1.1",
+    "@vercel/webpack-asset-relocator-loader": "1.2.0",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/test/unit/ts-decl-dir/output-coverage.js
+++ b/test/unit/ts-decl-dir/output-coverage.js
@@ -4,14 +4,14 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 676:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   "__esModule": () => /* reexport safe */ _test_ts__WEBPACK_IMPORTED_MODULE_0__.X,
 /* harmony export */   "test": () => /* reexport safe */ _test_ts__WEBPACK_IMPORTED_MODULE_0__.B
 /* harmony export */ });
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(867);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(867);
 
 
 
@@ -36,7 +36,7 @@ exports.B = test;
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -51,7 +51,7 @@ exports.B = test;
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -65,9 +65,9 @@ exports.B = test;
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
-/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
 /******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
 /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
 /******/ 				}
 /******/ 			}
@@ -76,13 +76,13 @@ exports.B = test;
 /******/ 	
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
-/******/ 		__webpack_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
+/******/ 		__nccwpck_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 /******/ 	})();
 /******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
-/******/ 		__webpack_require__.r = (exports) => {
+/******/ 		__nccwpck_require__.r = (exports) => {
 /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
 /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 			}
@@ -92,10 +92,10 @@ exports.B = test;
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(676);
+/******/ 	return __nccwpck_require__(676);
 /******/ })()
 ;

--- a/test/unit/ts-decl-dir/output.js
+++ b/test/unit/ts-decl-dir/output.js
@@ -4,14 +4,14 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 345:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   "__esModule": () => /* reexport safe */ _test_ts__WEBPACK_IMPORTED_MODULE_0__.X,
 /* harmony export */   "test": () => /* reexport safe */ _test_ts__WEBPACK_IMPORTED_MODULE_0__.B
 /* harmony export */ });
-/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(57);
+/* harmony import */ var _test_ts__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(57);
 
 
 
@@ -36,7 +36,7 @@ exports.B = test;
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -51,7 +51,7 @@ exports.B = test;
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -65,9 +65,9 @@ exports.B = test;
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
 /******/ 		// define getter functions for harmony exports
-/******/ 		__webpack_require__.d = (exports, definition) => {
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
 /******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
 /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
 /******/ 				}
 /******/ 			}
@@ -76,13 +76,13 @@ exports.B = test;
 /******/ 	
 /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
 /******/ 	(() => {
-/******/ 		__webpack_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
+/******/ 		__nccwpck_require__.o = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 /******/ 	})();
 /******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
-/******/ 		__webpack_require__.r = (exports) => {
+/******/ 		__nccwpck_require__.r = (exports) => {
 /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
 /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
 /******/ 			}
@@ -92,10 +92,10 @@ exports.B = test;
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(345);
+/******/ 	return __nccwpck_require__(345);
 /******/ })()
 ;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,10 +1902,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vercel/webpack-asset-relocator-loader@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.2.0.tgz#d8ac1cb9a1791775093b06207f82e7ee8bd6dfb0"
-  integrity sha512-xDcRbQLKTOZbyQLcdjfwgLaVzp8NLMDDReeqdC6WnfyFnXTniNZOEYuW6Og/bT3zqCbejJ36LSiXKxCLs63OEg==
+"@vercel/webpack-asset-relocator-loader@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.2.1.tgz#dd83e232f38fe1a77180028f46bad9103d12ae4c"
+  integrity sha512-LpO/dFl666D7Sxsxk+E/c2jutjkGzr7nDDHHcSv2zoQ8v50QqANflJCconOpnxLpAm7Y9Qf9IG8bDlXd1KAtpA==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,10 +1902,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vercel/webpack-asset-relocator-loader@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.1.1.tgz#fcc8a67099b94584f58bb25c71ddbfa723ef5eb6"
-  integrity sha512-yIi9HE1GfPK00eiNQvn/c0tOUjWLn+jJQT+kUToNkUG5AWh3j7SFzSNF7zh+fkCUUp0ij6HkwCUSpkiJ+Th3tw==
+"@vercel/webpack-asset-relocator-loader@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.2.0.tgz#d8ac1cb9a1791775093b06207f82e7ee8bd6dfb0"
+  integrity sha512-xDcRbQLKTOZbyQLcdjfwgLaVzp8NLMDDReeqdC6WnfyFnXTniNZOEYuW6Og/bT3zqCbejJ36LSiXKxCLs63OEg==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"


### PR DESCRIPTION
This includes the support for `customEmit` in dynamic require variable inlining.