### PR TITLE
Update to webpack-asset-relocator@1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@sentry/node": "^4.3.0",
     "@slack/web-api": "^5.13.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@vercel/webpack-asset-relocator-loader": "1.2.2",
+    "@vercel/webpack-asset-relocator-loader": "1.2.3",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,10 +1914,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vercel/webpack-asset-relocator-loader@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.2.2.tgz#f5ace8686602c9fbdfc95aed535253360b5dccf1"
-  integrity sha512-Re6pmZ4U5KMUDU5vP2zp3xSwTu1190qEvpnMELSXgsb/EaIIfhYEW0YNpMF0cA97UJYIwiQIGiaBQOu8kYmaiA==
+"@vercel/webpack-asset-relocator-loader@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.2.3.tgz#e911c0b9bbc10f7181a3f8accb3bd705b449b845"
+  integrity sha512-UsBARofgX+UJCRiHTmV636ZukstT1NV8QaWLJvEFxQMpaSSrnOWUXcYm4GX8iG8Bf3eqQoADRrGqCzaFkUyUSg==
 
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"


### PR DESCRIPTION
Contains fix to handle new name for node-pre-gyp. (Fix relocation of bcrypt@5.0.1)

Related https://github.com/vercel/webpack-asset-relocator-loader/pull/119