### PR TITLE
Interop test case

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -1,5 +1,9 @@
 [
   {
+    args: ["run", "test/fixtures/interop-test.js"],
+    expect: { code: 0 }
+  },
+  {
     args: ["run", "test/integration/test.ts"],
     expect: { code: 0 }
   },

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,6 +1,6 @@
 [
   {
-    args: ["run", "test/fixtures/interop-test.js"],
+    args: ["run", "test/fixtures/interop-test.mjs"],
     expect: { code: 0 }
   },
   {

--- a/test/fixtures/interop-test.js
+++ b/test/fixtures/interop-test.js
@@ -1,0 +1,3 @@
+import { strictEqual } from 'assert';
+import * as z from './interop.cjs';
+strictEqual(z.default, 'z');

--- a/test/fixtures/interop-test.js
+++ b/test/fixtures/interop-test.js
@@ -1,3 +1,0 @@
-import { strictEqual } from 'assert';
-import * as z from './interop.cjs';
-strictEqual(z.default, 'z');

--- a/test/fixtures/interop-test.mjs
+++ b/test/fixtures/interop-test.mjs
@@ -1,0 +1,7 @@
+import { strictEqual } from 'assert';
+import * as z from './interop.cjs';
+
+strictEqual(z.s, 's');
+strictEqual(z.__esModule, true);
+strictEqual(z.default.default, 'z');
+strictEqual(z.default.s, 's');

--- a/test/fixtures/interop.cjs
+++ b/test/fixtures/interop.cjs
@@ -1,0 +1,3 @@
+exports.s = 's';
+exports['com' + 'puted'] = 'y';
+exports.default = 'z';

--- a/test/fixtures/interop.cjs
+++ b/test/fixtures/interop.cjs
@@ -1,3 +1,5 @@
+Object.defineProperty(exports, '__esModule', { value: true });
 exports.s = 's';
 exports['com' + 'puted'] = 'y';
 exports.default = 'z';
+


### PR DESCRIPTION
This is a failing test case for one of the few of the remaining module interop cases that is different between Webpack and Node.js.

I'm hopeful we can get an upstream fix for this in Webpack in some form.