### PR TITLE
feat: imports support, webpack upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "vue": "^2.5.17",
     "vue-server-renderer": "^2.5.17",
     "web-vitals": "^0.2.4",
-    "webpack": "5.26.3",
+    "webpack": "5.27.1",
     "when": "^3.7.8"
   },
   "resolutions": {

--- a/test/unit/imports/input.js
+++ b/test/unit/imports/input.js
@@ -1,0 +1,2 @@
+import { x } from '#x';
+console.log(x);

--- a/test/unit/imports/no.js
+++ b/test/unit/imports/no.js
@@ -1,0 +1,1 @@
+export var y = 'y';

--- a/test/unit/imports/node.js
+++ b/test/unit/imports/node.js
@@ -1,0 +1,1 @@
+export var x = 'x';

--- a/test/unit/imports/output-coverage.js
+++ b/test/unit/imports/output-coverage.js
@@ -1,0 +1,34 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The require scope
+/******/ 	var __nccwpck_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__nccwpck_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+var __webpack_exports__ = {};
+// ESM COMPAT FLAG
+__nccwpck_require__.r(__webpack_exports__);
+
+;// CONCATENATED MODULE: ./test/unit/imports/node.js
+var x = 'x';
+
+;// CONCATENATED MODULE: ./test/unit/imports/input.js
+
+console.log(x);
+
+module.exports = __webpack_exports__;
+/******/ })()
+;

--- a/test/unit/imports/output.js
+++ b/test/unit/imports/output.js
@@ -1,0 +1,34 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The require scope
+/******/ 	var __nccwpck_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__nccwpck_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+var __webpack_exports__ = {};
+// ESM COMPAT FLAG
+__nccwpck_require__.r(__webpack_exports__);
+
+;// CONCATENATED MODULE: ./test/unit/imports/node.js
+var x = 'x';
+
+;// CONCATENATED MODULE: ./test/unit/imports/input.js
+
+console.log(x);
+
+module.exports = __webpack_exports__;
+/******/ })()
+;

--- a/test/unit/imports/package.json
+++ b/test/unit/imports/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "x",
+  "type": "module",
+  "imports": {
+    "#x": {
+      "module": "./no.js",
+      "default": {
+        "node": "./node.js"
+      }
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15008,10 +15008,10 @@ webpack-sources@^2.1.1:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
 
-webpack@5.26.3:
-  version "5.26.3"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.26.3.tgz#bafd439abac08fbb82657ec855d038743b725ab8"
-  integrity sha512-z/F2lt2N1fZqaud1B4SzjL3OW03eULThbBXQ2OX4LSrZX4N9k1A5d0Rje3zS2g887DTWyAV0KGqEf64ois2dhg==
+webpack@5.27.1:
+  version "5.27.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.27.1.tgz#6808fb6e45e35290cdb8ae43c7a10884839a3079"
+  integrity sha512-rxIDsPZ3Apl3JcqiemiLmWH+hAq04YeOXqvCxNZOnTp8ZgM9NEPtbu4CaMfMEf9KShnx/Ym8uLGmM6P4XnwCoA==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.46"


### PR DESCRIPTION
Upgrades to Webpack 5.27.1 with the "imports" fix, including a unit test for "imports" support.

Resolves https://github.com/vercel/ncc/issues/668.