### PR TITLE
deps: Upgrade to webpack-asset-relocator-loader@1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@sentry/node": "^4.3.0",
     "@slack/web-api": "^5.13.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@vercel/webpack-asset-relocator-loader": "1.2.3",
+    "@vercel/webpack-asset-relocator-loader": "1.2.4",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,10 +1914,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vercel/webpack-asset-relocator-loader@1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.2.3.tgz#e911c0b9bbc10f7181a3f8accb3bd705b449b845"
-  integrity sha512-UsBARofgX+UJCRiHTmV636ZukstT1NV8QaWLJvEFxQMpaSSrnOWUXcYm4GX8iG8Bf3eqQoADRrGqCzaFkUyUSg==
+"@vercel/webpack-asset-relocator-loader@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.2.4.tgz#a344305ad522105ad2248d5390b55d9da04a8074"
+  integrity sha512-QVricKHb9T8FdtCvdX9vd6J5SutJkUn8G9RgY7VdyR+HIcmd0KKNqKufmZcKWRCzvUya1yzX5H5iJZNXG8aO9g==
 
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"


### PR DESCRIPTION
Updates to version 1.2.4 with the better browserify wrapper handling and Acorn upgrade.