### PR TITLE
Update to webpack-asset-relocator-loader@1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@sentry/node": "^4.3.0",
     "@slack/web-api": "^5.13.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@vercel/webpack-asset-relocator-loader": "1.2.4",
+    "@vercel/webpack-asset-relocator-loader": "1.3.0",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,10 +1914,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vercel/webpack-asset-relocator-loader@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.2.4.tgz#a344305ad522105ad2248d5390b55d9da04a8074"
-  integrity sha512-QVricKHb9T8FdtCvdX9vd6J5SutJkUn8G9RgY7VdyR+HIcmd0KKNqKufmZcKWRCzvUya1yzX5H5iJZNXG8aO9g==
+"@vercel/webpack-asset-relocator-loader@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.3.0.tgz#b95a464bef6a2a6b5cc38ab7a00a84c3b65aff72"
+  integrity sha512-vDTciQkeycp25hPQbH3ZH7BWaClWCuwPRfzdPmLtrm2qD3YM8y3C+3r61Alt7gI7rEqKuoJJORtVGmpVGp5Isw==
 
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"


### PR DESCRIPTION
Featuring import.meta.url asset emission support via https://github.com/vercel/webpack-asset-relocator-loader/pull/122.
