### PR TITLE
fix:  unknown compiler option 'incremental'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -322,7 +322,11 @@ function ncc (
                 allowSyntheticDefaultImports: true,
                 module: 'esnext',
                 outDir: '//',
-                incremental: false,
+                ...(fullTsconfig &&
+                  fullTsconfig.compilerOptions &&
+                  fullTsconfig.compilerOptions.incremental
+                    ? { incremental: false }
+                    : {}),
                 noEmit: false
               }
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22665058/113830132-de0b6f00-97b8-11eb-9bd3-6c0f8b3a3b51.png)

When using a lower version of typescript, ts-loader will argue that there is an unknown compiler option `incremental`.