### PR TITLE
feat: support top-level await

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@sentry/node": "^4.3.0",
     "@slack/web-api": "^5.13.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@vercel/webpack-asset-relocator-loader": "1.3.0",
+    "@vercel/webpack-asset-relocator-loader": "1.4.0",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/src/index.js
+++ b/src/index.js
@@ -232,6 +232,9 @@ function ncc (
       module: { hash: true }
     },
     amd: false,
+    experiments: {
+      topLevelAwait: true
+    },
     optimization: {
       nodeEnv: false,
       minimize: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,10 +1959,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vercel/webpack-asset-relocator-loader@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.3.0.tgz#b95a464bef6a2a6b5cc38ab7a00a84c3b65aff72"
-  integrity sha512-vDTciQkeycp25hPQbH3ZH7BWaClWCuwPRfzdPmLtrm2qD3YM8y3C+3r61Alt7gI7rEqKuoJJORtVGmpVGp5Isw==
+"@vercel/webpack-asset-relocator-loader@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.4.0.tgz#48b52c59280d8d4c5490d0ad18826294ba5a4ece"
+  integrity sha512-AIEvl+wSzp8U4EoNnvpEelx2+dtRJT5zOm4X9wFVyLbOg3VqdKPQSqJ7ptVqr8z1X4CvqB9XK46uU3u6JAJuNg==
 
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"


### PR DESCRIPTION
Upgrades to webpack-asset-relocator@1.4.0 with TLA support and enables the webpack option.