### PR TITLE
fix: unify `target` arg description, add `transpile-only` arg to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,10 +63,11 @@ Outputs the Node.js compact build of `input.js` into `dist/index.js`.
   -e, --external [mod]     Skip bundling 'mod'. Can be used many times
   -q, --quiet              Disable build summaries / non-error outputs
   -w, --watch              Start a watched build
+  -t, --transpile-only     Use transpileOnly option with the ts-loader
   --v8-cache               Emit a build using the v8 compile cache
   --license [file]         Adds a file containing licensing information to the output
   --stats-out [file]       Emit webpack stats as json to the specified output file
-  --target [es2015|es2020] Select ecmascript target to use for output
+  --target [es2015|es2020] ECMAScript target to use for output (default: es2015)
 ```
 
 ### Execution Testing

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,8 @@ Outputs the Node.js compact build of `input.js` into `dist/index.js`.
   --v8-cache               Emit a build using the v8 compile cache
   --license [file]         Adds a file containing licensing information to the output
   --stats-out [file]       Emit webpack stats as json to the specified output file
-  --target [es] ECMAScript target to use for output (default: es2015) [Learn more](https://webpack.js.org/configuration/target)
+  --target [es]            ECMAScript target to use for output (default: es2015)
+                           Learn more: https://webpack.js.org/configuration/target
 ```
 
 ### Execution Testing

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Outputs the Node.js compact build of `input.js` into `dist/index.js`.
   --v8-cache               Emit a build using the v8 compile cache
   --license [file]         Adds a file containing licensing information to the output
   --stats-out [file]       Emit webpack stats as json to the specified output file
-  --target [es2015|es2020] ECMAScript target to use for output (default: es2015)
+  --target [es] ECMAScript target to use for output (default: es2015) [Learn more](https://webpack.js.org/configuration/target)
 ```
 
 ### Execution Testing

--- a/src/cli.js
+++ b/src/cli.js
@@ -35,7 +35,7 @@ Options:
   --v8-cache               Emit a build using the v8 compile cache
   --license [file]         Adds a file containing licensing information to the output
   --stats-out [file]       Emit webpack stats as json to the specified output file
-  --target [es2015|es2020] ECMAScript target to use for output (default: es2015)
+  --target [es] ECMAScript target to use for output (default: es2015)
 `;
 
 // support an API mode for CLI testing

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { resolve, relative, dirname, sep, extname } = require("path");
+const { resolve, relative, dirname, sep } = require("path");
 const glob = require("glob");
 const shebangRegEx = require("./utils/shebang");
 const rimraf = require("rimraf");
@@ -35,7 +35,7 @@ Options:
   --v8-cache               Emit a build using the v8 compile cache
   --license [file]         Adds a file containing licensing information to the output
   --stats-out [file]       Emit webpack stats as json to the specified output file
-  --target                  What build target to use for webpack (default: es6)
+  --target [es2015|es2020] ECMAScript target to use for output (default: es2015)
 `;
 
 // support an API mode for CLI testing

--- a/src/cli.js
+++ b/src/cli.js
@@ -35,7 +35,8 @@ Options:
   --v8-cache               Emit a build using the v8 compile cache
   --license [file]         Adds a file containing licensing information to the output
   --stats-out [file]       Emit webpack stats as json to the specified output file
-  --target [es] ECMAScript target to use for output (default: es2015)
+  --target [es]            ECMAScript target to use for output (default: es2015)
+                           Learn more: https://webpack.js.org/configuration/target
 `;
 
 // support an API mode for CLI testing

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ function ncc (
   }
 
   if (target && !target.startsWith('es')) {
-    throw new Error(`Invalid "target" value provided ${target}, value must be es version e.g. es5`)
+    throw new Error(`Invalid "target" value provided ${target}, value must be es version e.g. es2015`)
   }
 
   const resolvedEntry = resolve.sync(entry);


### PR DESCRIPTION
This simple PR aims to unify the `target` argument description between CLI usage comment and repo Readme file. 

I have also added missing `transpile-only` argument to the Readme file.

In addition `extname` import was removed by my IDE, because it was reported as unused import.