### PR TITLE
fix: treat compilation.errors as a set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -358,7 +358,7 @@ function ncc (
         compiler.close(err => {
           if (err) return reject(err);
           if (stats.hasErrors()) {
-            const errLog = stats.compilation.errors.map(err => err.message).join('\n');
+            const errLog = [...stats.compilation.errors].map(err => err.message).join('\n');
             return reject(new Error(errLog));
           }
           resolve(stats);


### PR DESCRIPTION
I believe this will resolve the deprecation warning in https://github.com/vercel/ncc/issues/704, by not assuming `compilation.errors` has array methods.