### PR TITLE
Update to webpack-asset-reloactor-loader@1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@sentry/node": "^4.3.0",
     "@slack/web-api": "^5.13.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@vercel/webpack-asset-relocator-loader": "1.4.0",
+    "@vercel/webpack-asset-relocator-loader": "1.5.0",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1954,10 +1954,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vercel/webpack-asset-relocator-loader@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.4.0.tgz#48b52c59280d8d4c5490d0ad18826294ba5a4ece"
-  integrity sha512-AIEvl+wSzp8U4EoNnvpEelx2+dtRJT5zOm4X9wFVyLbOg3VqdKPQSqJ7ptVqr8z1X4CvqB9XK46uU3u6JAJuNg==
+"@vercel/webpack-asset-relocator-loader@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.5.0.tgz#3b74caf02db3617c6f67e8f90f5696b51447f354"
+  integrity sha512-O5pHMhMz4H8YhaRjsJYnZ818kHF7V4Uz0DIn4AnITpqAiW7shgEbjDlTFZBX8hHOx53jTfhF8dWKCe+ffK3aeg==
 
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"


### PR DESCRIPTION
Includes https://github.com/vercel/webpack-asset-relocator-loader/pull/137 with support for private fields and numeric separators.