### PR TITLE
major: output ESM for .mjs or "type": "module" builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@sentry/node": "^4.3.0",
     "@slack/web-api": "^5.13.0",
     "@tensorflow/tfjs-node": "^0.3.0",
-    "@vercel/webpack-asset-relocator-loader": "1.5.0",
+    "@vercel/webpack-asset-relocator-loader": "1.6.0",
     "analytics-node": "^3.3.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "vue": "^2.5.17",
     "vue-server-renderer": "^2.5.17",
     "web-vitals": "^0.2.4",
-    "webpack": "5.43.0",
+    "webpack": "5.44.0",
     "when": "^3.7.8"
   },
   "resolutions": {

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,8 @@ Eg:
 $ ncc build input.js -o dist
 ```
 
+If building an `.mjs` or `.js` module inside a `"type": "module"` [package boundary](https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#packages_package_json_and_file_extensions), an ES module output will be created automatically.
+
 Outputs the Node.js compact build of `input.js` into `dist/index.js`.
 
 > Note: If the input file is using a `.cjs` extension, then so will the corresponding output file.

--- a/src/cli.js
+++ b/src/cli.js
@@ -25,7 +25,6 @@ Commands:
 Options:
   -o, --out [file]         Output directory for build (defaults to dist)
   
-  --esm                    Create an ES Module build output
   -m, --minify             Minify output
   -C, --no-cache           Skip build cache population
   -s, --source-map         Generate source map
@@ -131,7 +130,6 @@ async function runCmd (argv, stdout, stderr) {
     args = require("arg")({
       "--debug": Boolean,
       "-d": "--debug",
-      "--esm": Boolean,
       "--external": [String],
       "-e": "--external",
       "--out": String,
@@ -222,7 +220,6 @@ async function runCmd (argv, stdout, stderr) {
       if (existsSync(outDir))
         rimraf.sync(outDir);
       mkdirp.sync(outDir);
-      writeFileSync(eval('resolve')(outDir, 'package.json'), args['--esm'] ? '{ "type": "module" }' : '{}');
       run = true;
 
     // fallthrough
@@ -233,13 +230,12 @@ async function runCmd (argv, stdout, stderr) {
       let startTime = Date.now();
       let ps;
       const buildFile = eval("require.resolve")(resolve(args._[1] || "."));
-      const ext = !args['--esm'] && buildFile.endsWith('.cjs') ? '.cjs' : '.js';
+      const ext = buildFile.endsWith('.cjs') ? '.cjs' : buildFile.endsWith('.mjs') ? '.mjs' : '.js';
       const ncc = require("./index.js")(
         buildFile,
         {
           debugLog: args["--debug"],
           minify: args["--minify"],
-          esm: args["--esm"],
           externals: args["--external"],
           sourceMap: args["--source-map"] || run,
           sourceMapRegister: args["--no-source-map-register"] ? false : undefined,

--- a/src/cli.js
+++ b/src/cli.js
@@ -244,7 +244,7 @@ async function runCmd (argv, stdout, stderr) {
       let startTime = Date.now();
       let ps;
       const buildFile = eval("require.resolve")(resolve(args._[1] || "."));
-      const esm = buildFile.endsWith('.mjs') || buildFile.endsWith('.js') && hasTypeModule(buildFile);
+      const esm = buildFile.endsWith('.mjs') || !buildFile.endsWith('.cjs') && hasTypeModule(buildFile);
       const ext = buildFile.endsWith('.cjs') ? '.cjs' : esm && (buildFile.endsWith('.mjs') || !hasTypeModule(buildFile)) ? '.mjs' : '.js';
       const ncc = require("./index.js")(
         buildFile,

--- a/src/cli.js
+++ b/src/cli.js
@@ -244,7 +244,8 @@ async function runCmd (argv, stdout, stderr) {
       let startTime = Date.now();
       let ps;
       const buildFile = eval("require.resolve")(resolve(args._[1] || "."));
-      const ext = buildFile.endsWith('.cjs') ? '.cjs' : buildFile.endsWith('.mjs') || !hasTypeModule(buildFile) ? '.mjs' : '.js';
+      const esm = buildFile.endsWith('.mjs') || buildFile.endsWith('.js') && hasTypeModule(buildFile);
+      const ext = buildFile.endsWith('.cjs') ? '.cjs' : esm && (buildFile.endsWith('.mjs') || !hasTypeModule(buildFile)) ? '.mjs' : '.js';
       const ncc = require("./index.js")(
         buildFile,
         {

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,7 +5,7 @@ const glob = require("glob");
 const shebangRegEx = require("./utils/shebang");
 const rimraf = require("rimraf");
 const crypto = require("crypto");
-const { writeFileSync, unlink, existsSync, symlinkSync, mkdir } = require("fs");
+const { writeFileSync, unlink, existsSync, symlinkSync, readFileSync } = require("fs");
 const mkdirp = require("mkdirp");
 const { version: nccVersion } = require('../package.json');
 
@@ -231,7 +231,7 @@ async function runCmd (argv, stdout, stderr) {
         let root = resolve('/');
         while ((path = resolve(path, '..')) !== root) {
           try {
-            return JSON.parse(fs.readFileSync(eval('resolve')(path, 'package.json')).toString()).type === 'module';
+            return JSON.parse(readFileSync(eval('resolve')(path, 'package.json')).toString()).type === 'module';
           }
           catch (e) {
             if (e.code === 'ENOENT')

--- a/src/cli.js
+++ b/src/cli.js
@@ -228,10 +228,10 @@ async function runCmd (argv, stdout, stderr) {
         errTooManyArguments("build");
 
       function hasTypeModule (path) {
-        let root = pathResolve('/');
-        while ((path = pathResolve(path, '..')) !== root) {
+        let root = resolve('/');
+        while ((path = resolve(path, '..')) !== root) {
           try {
-            return JSON.parse(fs.readFileSync(eval('pathResolve')(path, 'package.json')).toString()).type === 'module';
+            return JSON.parse(fs.readFileSync(eval('resolve')(path, 'package.json')).toString()).type === 'module';
           }
           catch (e) {
             if (e.code === 'ENOENT')

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,7 +5,8 @@ const glob = require("glob");
 const shebangRegEx = require("./utils/shebang");
 const rimraf = require("rimraf");
 const crypto = require("crypto");
-const { writeFileSync, unlink, existsSync, symlinkSync, readFileSync } = require("fs");
+const { writeFileSync, unlink, existsSync, symlinkSync } = require("fs");
+const { hasTypeModule } = require('./utils/has-type-module');
 const mkdirp = require("mkdirp");
 const { version: nccVersion } = require('../package.json');
 
@@ -225,20 +226,6 @@ async function runCmd (argv, stdout, stderr) {
     case "build":
       if (args._.length > 2)
         errTooManyArguments("build");
-
-      function hasTypeModule (path) {
-        let root = resolve('/');
-        while ((path = resolve(path, '..')) !== root) {
-          try {
-            return JSON.parse(readFileSync(eval('resolve')(path, 'package.json')).toString()).type === 'module';
-          }
-          catch (e) {
-            if (e.code === 'ENOENT')
-              continue;
-            throw e;
-          }
-        }
-      }
 
       let startTime = Date.now();
       let ps;

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,6 @@ Commands:
 
 Options:
   -o, --out [file]         Output directory for build (defaults to dist)
-  
   -m, --minify             Minify output
   -C, --no-cache           Skip build cache population
   -s, --source-map         Generate source map

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,9 @@ function ncc (
     production = true,
   } = {}
 ) {
+  if (esm)
+    v8cache = false;
+
   const cjsDeps = () => ({
     mainFields: ["main"],
     extensions: SUPPORTED_EXTENSIONS,

--- a/src/index.js
+++ b/src/index.js
@@ -309,7 +309,7 @@ function ncc (
     node: false,
     externals ({ context, request }, callback) {
       const external = externalMap.get(request);
-      if (external) return callback(null, `commonjs ${external}`);
+      if (external) return callback(null, `${esm ? 'module' : 'commonjs'} ${external}`);
       return callback();
     },
     module: {

--- a/src/index.js
+++ b/src/index.js
@@ -252,7 +252,7 @@ function ncc (
     },
     devtool: sourceMap ? "cheap-module-source-map" : false,
     mode: "production",
-    target: target ? ["node", target] : "node",
+    target: target ? ["node14", target] : "node14",
     stats: {
       logging: 'error'
     },

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const shebangRegEx = require('./utils/shebang');
 const nccCacheDir = require("./utils/ncc-cache-dir");
 const LicenseWebpackPlugin = require('license-webpack-plugin').LicenseWebpackPlugin;
 const { version: nccVersion } = require('../package.json');
+const { hasTypeModule } = require('./utils/has-type-module');
 
 // support glob graceful-fs
 fs.gracefulify(require("fs"));
@@ -29,20 +30,6 @@ const hashOf = name => {
 const defaultPermissions = 0o666;
 
 const relocateLoader = eval('require(__dirname + "/loaders/relocate-loader.js")');
-
-function hasTypeModule (path) {
-  let root = pathResolve('/');
-  while ((path = pathResolve(path, '..')) !== root) {
-    try {
-      return JSON.parse(fs.readFileSync(eval('pathResolve')(path, 'package.json')).toString()).type === 'module';
-    }
-    catch (e) {
-      if (e.code === 'ENOENT')
-        continue;
-      throw e;
-    }
-  }
-}
 
 module.exports = ncc;
 function ncc (

--- a/src/index.js
+++ b/src/index.js
@@ -307,9 +307,9 @@ function ncc (
     },
     // https://github.com/vercel/ncc/pull/29#pullrequestreview-177152175
     node: false,
-    externals ({ context, request }, callback) {
+    externals ({ context, request, dependencyType }, callback) {
       const external = externalMap.get(request);
-      if (external) return callback(null, `${esm ? 'module' : 'commonjs'} ${external}`);
+      if (external) return callback(null, `${dependencyType === 'esm' && esm ? 'module' : 'node-commonjs'} ${external}`);
       return callback();
     },
     module: {

--- a/src/index.js
+++ b/src/index.js
@@ -538,7 +538,7 @@ function ncc (
       assets[`sourcemap-register${registerExt}`] = { source: fs.readFileSync(`${__dirname}/sourcemap-register.js.cache.js`), permissions: defaultPermissions };
     }
 
-    if (esm) {
+    if (esm && !filename.endsWith('.mjs')) {
       // always output a "type": "module" package JSON for esm builds
       const baseDir = dirname(filename);
       const pjsonPath = (baseDir === '.' ? '' : baseDir) + 'package.json';

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ function hasTypeModule (path) {
   let root = pathResolve('/');
   while ((path = pathResolve(path, '..')) !== root) {
     try {
-      return JSON.parse(fs.readFileSync(pathResolve(path, 'package.json')).toString()).type === 'module';
+      return JSON.parse(fs.readFileSync(eval('pathResolve')(path, 'package.json')).toString()).type === 'module';
     }
     catch (e) {
       if (e.code === 'ENOENT')
@@ -50,9 +50,9 @@ function ncc (
   {
     cache,
     customEmit = undefined,
-    esm = entry.endsWith('.mjs') || !entry.endsWith('.cjs') && hasTypeModule(pathResolve(entry)),
+    esm = entry.endsWith('.mjs') || !entry.endsWith('.cjs') && hasTypeModule(entry),
     externals = [],
-    filename = 'index' + (!esm && entry.endsWith('.cjs') ? '.cjs' : hasTypeModule(pathResolve(entry)) ? '.js' : '.mjs'),
+    filename = 'index' + (!esm && entry.endsWith('.cjs') ? '.cjs' : !esm || hasTypeModule(entry) ? '.js' : '.mjs'),
     minify = false,
     sourceMap = false,
     sourceMapRegister = true,
@@ -92,7 +92,7 @@ function ncc (
 
   if (!quiet) {
     console.log(`ncc: Version ${nccVersion}`);
-    console.log(`ncc: Compiling file ${filename} as ${esm ? 'ESM' : 'CJS'}`);
+    console.log(`ncc: Compiling file ${filename} into ${esm ? 'ESM' : 'CJS'}`);
   }
 
   if (target && !target.startsWith('es')) {
@@ -252,7 +252,7 @@ function ncc (
     amd: false,
     experiments: {
       topLevelAwait: true,
-      outputModule: true
+      outputModule: esm
     },
     optimization: {
       nodeEnv: false,

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ function ncc (
     customEmit = undefined,
     esm = entry.endsWith('.mjs') || !entry.endsWith('.cjs') && hasTypeModule(entry),
     externals = [],
-    filename = 'index' + (!esm && entry.endsWith('.cjs') ? '.cjs' : !esm || hasTypeModule(entry) ? '.js' : '.mjs'),
+    filename = 'index' + (!esm && entry.endsWith('.cjs') ? '.cjs' : esm && (entry.endsWith('.mjs') || !hasTypeModule(entry)) ? '.mjs' : '.js'),
     minify = false,
     sourceMap = false,
     sourceMapRegister = true,
@@ -70,6 +70,7 @@ function ncc (
     production = true,
   } = {}
 ) {
+  // v8 cache not supported for ES modules
   if (esm)
     v8cache = false;
 

--- a/src/utils/has-type-module.js
+++ b/src/utils/has-type-module.js
@@ -1,0 +1,15 @@
+const { resolve } = require('path');
+const { readFileSync } = require('fs');
+
+exports.hasTypeModule = function hasTypeModule (path) {
+  while (path !== (path = resolve(path, '..'))) {
+    try {
+      return JSON.parse(readFileSync(eval('resolve')(path, 'package.json')).toString()).type === 'module';
+    }
+    catch (e) {
+      if (e.code === 'ENOENT')
+        continue;
+      throw e;
+    }
+  }
+}

--- a/test/cli.js
+++ b/test/cli.js
@@ -103,5 +103,12 @@
     expect (code, stdout) { 
       return code === 0 && stdout.indexOf('ncc built-in') !== -1;
     },
+  },
+  {
+    args: ["build", "-o", "tmp", "test/fixtures/module.cjs", "--esm"],
+    expect (code, stdout) {
+      const fs = require('fs');
+      return code === 0 && fs.readFileSync('tmp/index.js', 'utf8').toString().indexOf('export {') !== -1;
+    }
   }
 ]

--- a/test/cli.js
+++ b/test/cli.js
@@ -73,7 +73,7 @@
   {
     args: ["build", "-o", "tmp", "test/fixtures/test.mjs"],
     expect (code, stdout, stderr) {
-      return stdout.toString().indexOf('tmp/index.js') !== -1;
+      return stdout.toString().indexOf('tmp/index.mjs') !== -1;
     }
   },
   {
@@ -105,10 +105,10 @@
     },
   },
   {
-    args: ["build", "-o", "tmp", "test/fixtures/module.cjs", "--esm"],
+    args: ["build", "-o", "tmp", "test/fixtures/module.cjs"],
     expect (code, stdout) {
       const fs = require('fs');
-      return code === 0 && fs.readFileSync('tmp/index.js', 'utf8').toString().indexOf('export {') !== -1;
+      return code === 0 && fs.readFileSync('tmp/index.js', 'utf8').toString().indexOf('export {') === -1;
     }
   }
 ]

--- a/test/fixtures/module.cjs
+++ b/test/fixtures/module.cjs
@@ -1,0 +1,3 @@
+require('./no-dep.js');
+
+exports.aRealExport = true;

--- a/test/unit/bundle-subasset/output-coverage.js
+++ b/test/unit/bundle-subasset/output-coverage.js
@@ -84,7 +84,9 @@ module.exports = require("path");
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/bundle-subasset/output.js
+++ b/test/unit/bundle-subasset/output.js
@@ -84,7 +84,9 @@ module.exports = require("path");
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/bundle-subasset2/output-coverage.js
+++ b/test/unit/bundle-subasset2/output-coverage.js
@@ -75,7 +75,9 @@
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);

--- a/test/unit/bundle-subasset2/output.js
+++ b/test/unit/bundle-subasset2/output.js
@@ -75,7 +75,9 @@
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);

--- a/test/unit/custom-emit/output-coverage.js
+++ b/test/unit/custom-emit/output-coverage.js
@@ -44,7 +44,9 @@ module.exports = require("fs");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/custom-emit/output.js
+++ b/test/unit/custom-emit/output.js
@@ -44,7 +44,9 @@ module.exports = require("fs");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/exports-nomodule/output-coverage.js
+++ b/test/unit/exports-nomodule/output-coverage.js
@@ -1,7 +1,9 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ 
+/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/exports-nomodule/node.js

--- a/test/unit/exports-nomodule/output-coverage.js
+++ b/test/unit/exports-nomodule/output-coverage.js
@@ -1,26 +1,8 @@
-/******/ (() => { // webpackBootstrap
-/******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __nccwpck_require__ = {};
-/******/ 	
-/************************************************************************/
-/******/ 	/* webpack/runtime/make namespace object */
-/******/ 	(() => {
-/******/ 		// define __esModule on exports
-/******/ 		__nccwpck_require__.r = (exports) => {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
-/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ "use strict";
+/******/ /* webpack/runtime/compat */
+/******/ 
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 var __webpack_exports__ = {};
-// ESM COMPAT FLAG
-__nccwpck_require__.r(__webpack_exports__);
 
 ;// CONCATENATED MODULE: ./test/unit/exports-nomodule/node.js
 var x = 'x';
@@ -28,7 +10,3 @@ var x = 'x';
 ;// CONCATENATED MODULE: ./test/unit/exports-nomodule/input.js
 
 console.log(x);
-
-module.exports = __webpack_exports__;
-/******/ })()
-;

--- a/test/unit/exports-nomodule/output-coverage.js
+++ b/test/unit/exports-nomodule/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/exports-nomodule/node.js

--- a/test/unit/exports-nomodule/output.js
+++ b/test/unit/exports-nomodule/output.js
@@ -1,7 +1,9 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ 
+/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/exports-nomodule/node.js

--- a/test/unit/exports-nomodule/output.js
+++ b/test/unit/exports-nomodule/output.js
@@ -1,26 +1,8 @@
-/******/ (() => { // webpackBootstrap
-/******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __nccwpck_require__ = {};
-/******/ 	
-/************************************************************************/
-/******/ 	/* webpack/runtime/make namespace object */
-/******/ 	(() => {
-/******/ 		// define __esModule on exports
-/******/ 		__nccwpck_require__.r = (exports) => {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
-/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ "use strict";
+/******/ /* webpack/runtime/compat */
+/******/ 
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 var __webpack_exports__ = {};
-// ESM COMPAT FLAG
-__nccwpck_require__.r(__webpack_exports__);
 
 ;// CONCATENATED MODULE: ./test/unit/exports-nomodule/node.js
 var x = 'x';
@@ -28,7 +10,3 @@ var x = 'x';
 ;// CONCATENATED MODULE: ./test/unit/exports-nomodule/input.js
 
 console.log(x);
-
-module.exports = __webpack_exports__;
-/******/ })()
-;

--- a/test/unit/exports-nomodule/output.js
+++ b/test/unit/exports-nomodule/output.js
@@ -1,7 +1,7 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/exports-nomodule/node.js

--- a/test/unit/exports-wildcard/output-coverage.js
+++ b/test/unit/exports-wildcard/output-coverage.js
@@ -1,7 +1,9 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ 
+/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/exports-wildcard/node.js

--- a/test/unit/exports-wildcard/output-coverage.js
+++ b/test/unit/exports-wildcard/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/exports-wildcard/node.js

--- a/test/unit/exports-wildcard/output-coverage.js
+++ b/test/unit/exports-wildcard/output-coverage.js
@@ -1,26 +1,8 @@
-/******/ (() => { // webpackBootstrap
-/******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __nccwpck_require__ = {};
-/******/ 	
-/************************************************************************/
-/******/ 	/* webpack/runtime/make namespace object */
-/******/ 	(() => {
-/******/ 		// define __esModule on exports
-/******/ 		__nccwpck_require__.r = (exports) => {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
-/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ "use strict";
+/******/ /* webpack/runtime/compat */
+/******/ 
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 var __webpack_exports__ = {};
-// ESM COMPAT FLAG
-__nccwpck_require__.r(__webpack_exports__);
 
 ;// CONCATENATED MODULE: ./test/unit/exports-wildcard/node.js
 var y = 'y';
@@ -28,7 +10,3 @@ var y = 'y';
 ;// CONCATENATED MODULE: ./test/unit/exports-wildcard/input.js
 
 console.log(y);
-
-module.exports = __webpack_exports__;
-/******/ })()
-;

--- a/test/unit/exports-wildcard/output.js
+++ b/test/unit/exports-wildcard/output.js
@@ -1,7 +1,9 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ 
+/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/exports-wildcard/node.js

--- a/test/unit/exports-wildcard/output.js
+++ b/test/unit/exports-wildcard/output.js
@@ -1,7 +1,7 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/exports-wildcard/node.js

--- a/test/unit/exports-wildcard/output.js
+++ b/test/unit/exports-wildcard/output.js
@@ -1,26 +1,8 @@
-/******/ (() => { // webpackBootstrap
-/******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __nccwpck_require__ = {};
-/******/ 	
-/************************************************************************/
-/******/ 	/* webpack/runtime/make namespace object */
-/******/ 	(() => {
-/******/ 		// define __esModule on exports
-/******/ 		__nccwpck_require__.r = (exports) => {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
-/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ "use strict";
+/******/ /* webpack/runtime/compat */
+/******/ 
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 var __webpack_exports__ = {};
-// ESM COMPAT FLAG
-__nccwpck_require__.r(__webpack_exports__);
 
 ;// CONCATENATED MODULE: ./test/unit/exports-wildcard/node.js
 var y = 'y';
@@ -28,7 +10,3 @@ var y = 'y';
 ;// CONCATENATED MODULE: ./test/unit/exports-wildcard/input.js
 
 console.log(y);
-
-module.exports = __webpack_exports__;
-/******/ })()
-;

--- a/test/unit/externals/output-coverage.js
+++ b/test/unit/externals/output-coverage.js
@@ -52,7 +52,9 @@ module.exports = require("regexexternal");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/externals/output.js
+++ b/test/unit/externals/output.js
@@ -52,7 +52,9 @@ module.exports = require("regexexternal");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/imports/output-coverage.js
+++ b/test/unit/imports/output-coverage.js
@@ -1,7 +1,9 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ 
+/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/imports/node.js

--- a/test/unit/imports/output-coverage.js
+++ b/test/unit/imports/output-coverage.js
@@ -1,26 +1,8 @@
-/******/ (() => { // webpackBootstrap
-/******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __nccwpck_require__ = {};
-/******/ 	
-/************************************************************************/
-/******/ 	/* webpack/runtime/make namespace object */
-/******/ 	(() => {
-/******/ 		// define __esModule on exports
-/******/ 		__nccwpck_require__.r = (exports) => {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
-/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ "use strict";
+/******/ /* webpack/runtime/compat */
+/******/ 
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 var __webpack_exports__ = {};
-// ESM COMPAT FLAG
-__nccwpck_require__.r(__webpack_exports__);
 
 ;// CONCATENATED MODULE: ./test/unit/imports/node.js
 var x = 'x';
@@ -28,7 +10,3 @@ var x = 'x';
 ;// CONCATENATED MODULE: ./test/unit/imports/input.js
 
 console.log(x);
-
-module.exports = __webpack_exports__;
-/******/ })()
-;

--- a/test/unit/imports/output-coverage.js
+++ b/test/unit/imports/output-coverage.js
@@ -1,7 +1,7 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/imports/node.js

--- a/test/unit/imports/output.js
+++ b/test/unit/imports/output.js
@@ -1,7 +1,9 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ 
+/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/imports/node.js

--- a/test/unit/imports/output.js
+++ b/test/unit/imports/output.js
@@ -1,26 +1,8 @@
-/******/ (() => { // webpackBootstrap
-/******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __nccwpck_require__ = {};
-/******/ 	
-/************************************************************************/
-/******/ 	/* webpack/runtime/make namespace object */
-/******/ 	(() => {
-/******/ 		// define __esModule on exports
-/******/ 		__nccwpck_require__.r = (exports) => {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
-/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 		};
-/******/ 	})();
-/******/ 	
-/******/ 	/* webpack/runtime/compat */
-/******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ "use strict";
+/******/ /* webpack/runtime/compat */
+/******/ 
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 var __webpack_exports__ = {};
-// ESM COMPAT FLAG
-__nccwpck_require__.r(__webpack_exports__);
 
 ;// CONCATENATED MODULE: ./test/unit/imports/node.js
 var x = 'x';
@@ -28,7 +10,3 @@ var x = 'x';
 ;// CONCATENATED MODULE: ./test/unit/imports/input.js
 
 console.log(x);
-
-module.exports = __webpack_exports__;
-/******/ })()
-;

--- a/test/unit/imports/output.js
+++ b/test/unit/imports/output.js
@@ -1,7 +1,7 @@
 /******/ "use strict";
 /******/ /* webpack/runtime/compat */
 /******/ 
-/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = new URL('.', import.meta.url).pathname.slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";/************************************************************************/
 var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: ./test/unit/imports/node.js

--- a/test/unit/minify-err/output-coverage.js
+++ b/test/unit/minify-err/output-coverage.js
@@ -64,7 +64,9 @@ module.exports = require("fs");
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/minify-err/output.js
+++ b/test/unit/minify-err/output.js
@@ -64,7 +64,9 @@ module.exports = require("fs");
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/runtime-notfound/output-coverage.js
+++ b/test/unit/runtime-notfound/output-coverage.js
@@ -52,7 +52,9 @@ module.exports = eval("require")("./not-found.js");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/runtime-notfound/output.js
+++ b/test/unit/runtime-notfound/output.js
@@ -52,7 +52,9 @@ module.exports = eval("require")("./not-found.js");
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {

--- a/test/unit/shebang/output-coverage.js
+++ b/test/unit/shebang/output-coverage.js
@@ -44,7 +44,9 @@ module.exports = 'asdf';
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports

--- a/test/unit/shebang/output.js
+++ b/test/unit/shebang/output.js
@@ -44,7 +44,9 @@ module.exports = 'asdf';
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 /******/ 	
 /******/ 	// startup
 /******/ 	// Load entry module and return exports

--- a/test/unit/ts-decl-dir/output-coverage.js
+++ b/test/unit/ts-decl-dir/output-coverage.js
@@ -34,7 +34,9 @@
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);

--- a/test/unit/ts-decl-dir/output.js
+++ b/test/unit/ts-decl-dir/output.js
@@ -34,7 +34,9 @@
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);

--- a/test/unit/ts-decl/output-coverage.js
+++ b/test/unit/ts-decl/output-coverage.js
@@ -34,7 +34,9 @@
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);

--- a/test/unit/ts-decl/output.js
+++ b/test/unit/ts-decl/output.js
@@ -34,7 +34,9 @@
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);

--- a/test/unit/ts-exts/output-coverage.js
+++ b/test/unit/ts-exts/output-coverage.js
@@ -17,7 +17,9 @@
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);

--- a/test/unit/ts-exts/output.js
+++ b/test/unit/ts-exts/output.js
@@ -17,7 +17,9 @@
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);

--- a/test/unit/tsconfig-paths-allowjs/output-coverage.js
+++ b/test/unit/tsconfig-paths-allowjs/output-coverage.js
@@ -17,7 +17,9 @@
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);

--- a/test/unit/tsconfig-paths-allowjs/output.js
+++ b/test/unit/tsconfig-paths-allowjs/output.js
@@ -84,7 +84,9 @@ module.exports = eval("require")("@module");
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be in strict mode.
 (() => {

--- a/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
@@ -17,7 +17,9 @@
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);

--- a/test/unit/tsconfig-paths-conflicting-external/output.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output.js
@@ -84,7 +84,9 @@ module.exports = eval("require")("@module");
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be in strict mode.
 (() => {

--- a/test/unit/tsconfig-paths/output-coverage.js
+++ b/test/unit/tsconfig-paths/output-coverage.js
@@ -17,7 +17,9 @@
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);

--- a/test/unit/tsconfig-paths/output.js
+++ b/test/unit/tsconfig-paths/output.js
@@ -84,7 +84,9 @@ module.exports = eval("require")("@module");
 /******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be in strict mode.
 (() => {

--- a/test/watcher.test.js
+++ b/test/watcher.test.js
@@ -93,7 +93,7 @@ class CustomWatchFileSystem {
   }
 }
 
-jest.setTimeout(60000);
+jest.setTimeout(30000);
 
 it('Should support custom watch API', async () => {
   let buildCnt = 0;

--- a/update-fixtures.sh
+++ b/update-fixtures.sh
@@ -1,0 +1,5 @@
+yarn run build
+jest test/unit
+for f in test/unit/*; do mv $f/actual.js $f/output.js; done
+node --expose-gc node_modules/.bin/jest --coverage --globals "{\"coverage\":true}" test/unit
+for f in test/unit/*; do mv $f/actual.js $f/output-coverage.js; done

--- a/yarn.lock
+++ b/yarn.lock
@@ -2155,10 +2155,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vercel/webpack-asset-relocator-loader@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.5.0.tgz#3b74caf02db3617c6f67e8f90f5696b51447f354"
-  integrity sha512-O5pHMhMz4H8YhaRjsJYnZ818kHF7V4Uz0DIn4AnITpqAiW7shgEbjDlTFZBX8hHOx53jTfhF8dWKCe+ffK3aeg==
+"@vercel/webpack-asset-relocator-loader@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.6.0.tgz#5c1359187a1f88fbf212c05ba8291bc17441e510"
+  integrity sha512-Iy7uTSeiYn78Gc0flRHxlBFLn32/q9i70Ss8MKO37g2fYHdCYhbLbZg1cfQ5DgXv0SQqBdWimF4Md4hcgH/jhw==
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1835,10 +1835,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
   integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
 
-"@types/estree@^0.0.49":
-  version "0.0.49"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.49.tgz#3facb98ebcd4114a4ecef74e0de2175b56fd4464"
-  integrity sha512-K1AFuMe8a+pXmfHTtnwBvqoEylNKVeaiKYkjmcEAdytMQVJ/i9Fu7sc13GxgXdO49gkE7Hy8SyJonUZUn+eVaw==
+"@types/estree@^0.0.50":
+  version "0.0.50"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
+  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
 "@types/express-jwt@0.0.42":
   version "0.0.42"
@@ -15528,13 +15528,13 @@ webpack-sources@^2.3.0:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
 
-webpack@5.43.0:
-  version "5.43.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.43.0.tgz#36a122d6e9bac3836273857f56ed7801d40c9145"
-  integrity sha512-ex3nB9uxNI0azzb0r3xGwi+LS5Gw1RCRSKk0kg3kq9MYdIPmLS6UI3oEtG7esBaB51t9I+5H+vHmL3htaxqMSw==
+webpack@5.44.0:
+  version "5.44.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.44.0.tgz#97b13a02bd79fb71ac6301ce697920660fa214a1"
+  integrity sha512-I1S1w4QLoKmH19pX6YhYN0NiSXaWY8Ou00oA+aMcr9IUGeF5azns+IKBkfoAAG9Bu5zOIzZt/mN35OffBya8AQ==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
-    "@types/estree" "^0.0.49"
+    "@types/estree" "^0.0.50"
     "@webassemblyjs/ast" "1.11.1"
     "@webassemblyjs/wasm-edit" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"


### PR DESCRIPTION
This adds support to ncc for a new `esm` option to output ES modules from the build. It defaults to true when the input file is ".mjs" or the input file is contained within a "type": "module" boundary.

The support is based on Webpack's experimental support which seems to have a few edge cases that I have posted in https://github.com/webpack/webpack/issues/13639.

If releasing this feature it would be best to treat it as having an experimental status just like the Webpack feature it exposes.

Resolves https://github.com/vercel/ncc/issues/679.

To be merged after https://github.com/vercel/ncc/pull/723 and https://github.com/vercel/webpack-asset-relocator-loader/pull/140, https://github.com/vercel/ncc/pull/724.