### PR TITLE
fix: package.json asset type module setting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -531,7 +531,7 @@ function ncc (
       const baseDir = dirname(filename);
       const pjsonPath = (baseDir === '.' ? '' : baseDir) + 'package.json';
       if (assets[pjsonPath])
-        assets[pjsonPath].source = JSON.stringify(Object.assign(JSON.parse(pjsonPath.source.toString()), { type: 'module' }));
+        assets[pjsonPath].source = JSON.stringify(Object.assign(JSON.parse(assets[pjsonPath].source.toString()), { type: 'module' }));
       else
         assets[pjsonPath] = { source: JSON.stringify({ type: 'module' }, null, 2) + '\n', permissions: defaultPermissions };
     }

--- a/test/cli.js
+++ b/test/cli.js
@@ -12,7 +12,7 @@
     expect: { code: 0 }
   },
   {
-    args: ["build", "test/integration/type-module/main.js", "-", "tmp"],
+    args: ["build", "test/integration/type-module/main.js", "-o", "tmp"],
     expect: { code: 0 }
   },
   {

--- a/test/cli.js
+++ b/test/cli.js
@@ -12,6 +12,10 @@
     expect: { code: 0 }
   },
   {
+    args: ["build", "test/integration/type-module/main.js", "-", "tmp"],
+    expect: { code: 0 }
+  },
+  {
     args: ["build", "test/integration/test.ts", "-o", "tmp"],
     expect (code, stdout, stderr) {
       return stdout.toString().indexOf('tmp/index.js') !== -1;

--- a/test/cli.js
+++ b/test/cli.js
@@ -12,7 +12,7 @@
     expect: { code: 0 }
   },
   {
-    args: ["build", "test/integration/type-module/main.js", "-o", "tmp"],
+    args: ["build", "test/fixtures/type-module/main.js", "-o", "tmp"],
     expect: { code: 0 }
   },
   {

--- a/test/fixtures/type-module/main.js
+++ b/test/fixtures/type-module/main.js
@@ -1,0 +1,6 @@
+import { readFileSync } from 'fs';
+
+readFileSync(new URL('./package.json', import.meta.url));
+
+export var p = 5;
+

--- a/test/fixtures/type-module/package.json
+++ b/test/fixtures/type-module/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
This fixes https://github.com/vercel/ncc/issues/732, which was a feature added to ensure any emitted `package.json` doesn't stop the `"type": "module"` boundary from applying, but had a typo in the reading process.