### PR TITLE
fix: ensure nested builds of __nccwpck_require__

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -546,8 +546,22 @@ function ncc (
     // __webpack_require__ can conflict with webpack injections in module scopes
     // to avoid this without recomputing the source map we replace it with an
     // identical length identifier
-    if (code.indexOf('"__webpack_require__"') === -1)
+    if (code.indexOf('"__webpack_require__"') === -1) {
+      // dedupe any existing __nccwpck_require__ first
+      if (code.indexOf('__nccwpck_require2_') !== -1) {
+        // nth level nesting (we support 9 levels apparently)
+        for (let i = 9; i > 1; i--) {
+          if (code.indexOf(`__nccwpck_require${i}_`) === -1)
+            continue;
+          if (i === 9)
+            throw new Error('9 levels of ncc build nesting reached, please post an issue to support this level of ncc build composition.');
+          code = code.replace(/__nccwpck_require${i}_/g, `__nccwpck_require${i + 1}_`);
+        }
+      }
+      if (code.indexOf('__nccwpck_require__') !== -1)
+        code = code.replace(/__nccwpck_require__/g, '__nccwpck_require2_');
       code = code.replace(/__webpack_require__/g, '__nccwpck_require__');
+    }
 
     // for each .js / .mjs / .cjs file in the asset list, build that file with ncc itself
     if (!noAssetBuilds) {

--- a/src/index.js
+++ b/src/index.js
@@ -555,7 +555,7 @@ function ncc (
             continue;
           if (i === 9)
             throw new Error('9 levels of ncc build nesting reached, please post an issue to support this level of ncc build composition.');
-          code = code.replace(/__nccwpck_require${i}_/g, `__nccwpck_require${i + 1}_`);
+          code = code.replace(new RegExp(`__nccwpck_require${i}_`, 'g'), `__nccwpck_require${i + 1}_`);
         }
       }
       if (code.indexOf('__nccwpck_require__') !== -1)

--- a/test/unit/double-nested-builds/input.js
+++ b/test/unit/double-nested-builds/input.js
@@ -1,0 +1,175 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 332:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 622:
+/***/ ((module) => {
+
+  module.exports = __nccwpck_require__(622);
+
+  /***/ })
+  
+  /******/ 	});
+  /************************************************************************/
+  /******/ 	// The module cache
+  /******/ 	var __webpack_module_cache__ = {};
+  /******/ 	
+  /******/ 	// The require function
+  /******/ 	function __nccwpck_require2_(moduleId) {
+  /******/ 		// Check if module is in cache
+  /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+  /******/ 		if (cachedModule !== undefined) {
+  /******/ 			return cachedModule.exports;
+  /******/ 		}
+  /******/ 		// Create a new module (and put it into the cache)
+  /******/ 		var module = __webpack_module_cache__[moduleId] = {
+  /******/ 			// no module.id needed
+  /******/ 			// no module.loaded needed
+  /******/ 			exports: {}
+  /******/ 		};
+  /******/ 	
+  /******/ 		// Execute the module function
+  /******/ 		var threw = true;
+  /******/ 		try {
+  /******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require2_);
+  /******/ 			threw = false;
+  /******/ 		} finally {
+  /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+  /******/ 		}
+  /******/ 	
+  /******/ 		// Return the exports of the module
+  /******/ 		return module.exports;
+  /******/ 	}
+  /******/ 	
+  /************************************************************************/
+  /******/ 	/* webpack/runtime/compat get default export */
+  /******/ 	(() => {
+  /******/ 		// getDefaultExport function for compatibility with non-harmony modules
+  /******/ 		__nccwpck_require2_.n = (module) => {
+  /******/ 			var getter = module && module.__esModule ?
+  /******/ 				() => (module['default']) :
+  /******/ 				() => (module);
+  /******/ 			__nccwpck_require2_.d(getter, { a: getter });
+  /******/ 			return getter;
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/define property getters */
+  /******/ 	(() => {
+  /******/ 		// define getter functions for harmony exports
+  /******/ 		__nccwpck_require2_.d = (exports, definition) => {
+  /******/ 			for(var key in definition) {
+  /******/ 				if(__nccwpck_require2_.o(definition, key) && !__nccwpck_require2_.o(exports, key)) {
+  /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+  /******/ 				}
+  /******/ 			}
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+  /******/ 	(() => {
+  /******/ 		__nccwpck_require2_.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/make namespace object */
+  /******/ 	(() => {
+  /******/ 		// define __esModule on exports
+  /******/ 		__nccwpck_require2_.r = (exports) => {
+  /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+  /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+  /******/ 			}
+  /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/compat */
+  /******/ 	
+  /******/ 	if (typeof __nccwpck_require2_ !== 'undefined') __nccwpck_require2_.ab = __dirname + "/";
+  /******/ 	
+  /************************************************************************/
+  var __webpack_exports__ = {};
+  // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+  (() => {
+  __nccwpck_require2_.r(__webpack_exports__);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require2_(622);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require2_.n(path__WEBPACK_IMPORTED_MODULE_0__);
+  
+  
+  const file = __nccwpck_require2_.ab + "pi-bridge.js";
+  
+  const obscureRequire = eval(`function obscureRequire (file) {
+      require(file);
+  }`);
+  
+  console.log(obscureRequire(__nccwpck_require2_.ab + "pi-bridge.js"));
+  
+  })();
+  
+  module.exports = __webpack_exports__;
+  /******/ })()
+  ;
+  
+
+/***/ }),
+
+/***/ 622:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("path");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(332);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;

--- a/test/unit/double-nested-builds/output-coverage.js
+++ b/test/unit/double-nested-builds/output-coverage.js
@@ -1,0 +1,239 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 206:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 332:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require2_) => {
+
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 622:
+/***/ ((module) => {
+
+  module.exports = __nccwpck_require2_(622);
+
+  /***/ })
+  
+  /******/ 	});
+  /************************************************************************/
+  /******/ 	// The module cache
+  /******/ 	var __webpack_module_cache__ = {};
+  /******/ 	
+  /******/ 	// The require function
+  /******/ 	function __nccwpck_require3_(moduleId) {
+  /******/ 		// Check if module is in cache
+  /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+  /******/ 		if (cachedModule !== undefined) {
+  /******/ 			return cachedModule.exports;
+  /******/ 		}
+  /******/ 		// Create a new module (and put it into the cache)
+  /******/ 		var module = __webpack_module_cache__[moduleId] = {
+  /******/ 			// no module.id needed
+  /******/ 			// no module.loaded needed
+  /******/ 			exports: {}
+  /******/ 		};
+  /******/ 	
+  /******/ 		// Execute the module function
+  /******/ 		var threw = true;
+  /******/ 		try {
+  /******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require3_);
+  /******/ 			threw = false;
+  /******/ 		} finally {
+  /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+  /******/ 		}
+  /******/ 	
+  /******/ 		// Return the exports of the module
+  /******/ 		return module.exports;
+  /******/ 	}
+  /******/ 	
+  /************************************************************************/
+  /******/ 	/* webpack/runtime/compat get default export */
+  /******/ 	(() => {
+  /******/ 		// getDefaultExport function for compatibility with non-harmony modules
+  /******/ 		__nccwpck_require3_.n = (module) => {
+  /******/ 			var getter = module && module.__esModule ?
+  /******/ 				() => (module['default']) :
+  /******/ 				() => (module);
+  /******/ 			__nccwpck_require3_.d(getter, { a: getter });
+  /******/ 			return getter;
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/define property getters */
+  /******/ 	(() => {
+  /******/ 		// define getter functions for harmony exports
+  /******/ 		__nccwpck_require3_.d = (exports, definition) => {
+  /******/ 			for(var key in definition) {
+  /******/ 				if(__nccwpck_require3_.o(definition, key) && !__nccwpck_require3_.o(exports, key)) {
+  /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+  /******/ 				}
+  /******/ 			}
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+  /******/ 	(() => {
+  /******/ 		__nccwpck_require3_.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/make namespace object */
+  /******/ 	(() => {
+  /******/ 		// define __esModule on exports
+  /******/ 		__nccwpck_require3_.r = (exports) => {
+  /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+  /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+  /******/ 			}
+  /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/compat */
+  /******/ 	
+  /******/ 	if (typeof __nccwpck_require3_ !== 'undefined') __nccwpck_require3_.ab = __dirname + "/";
+  /******/ 	
+  /************************************************************************/
+  var __webpack_exports__ = {};
+  // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+  (() => {
+  __nccwpck_require3_.r(__webpack_exports__);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require3_(622);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require3_.n(path__WEBPACK_IMPORTED_MODULE_0__);
+  
+  
+  const file = __nccwpck_require3_.ab + "pi-bridge.js";
+  
+  const obscureRequire = eval(`function obscureRequire (file) {
+      require(file);
+  }`);
+  
+  console.log(obscureRequire(__nccwpck_require3_.ab + "pi-bridge.js"));
+  
+  })();
+  
+  module.exports = __webpack_exports__;
+  /******/ })()
+  ;
+  
+
+/***/ }),
+
+/***/ 622:
+/***/ ((module) => {
+
+"use strict";
+module.exports = __nccwpck_require__(622);
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require2_(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require2_);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require2_ !== 'undefined') __nccwpck_require2_.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require2_(332);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;
+
+/***/ }),
+
+/***/ 622:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("path");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(206);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;

--- a/test/unit/double-nested-builds/output.js
+++ b/test/unit/double-nested-builds/output.js
@@ -1,0 +1,239 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 39:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 332:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require2_) => {
+
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 622:
+/***/ ((module) => {
+
+  module.exports = __nccwpck_require2_(622);
+
+  /***/ })
+  
+  /******/ 	});
+  /************************************************************************/
+  /******/ 	// The module cache
+  /******/ 	var __webpack_module_cache__ = {};
+  /******/ 	
+  /******/ 	// The require function
+  /******/ 	function __nccwpck_require3_(moduleId) {
+  /******/ 		// Check if module is in cache
+  /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+  /******/ 		if (cachedModule !== undefined) {
+  /******/ 			return cachedModule.exports;
+  /******/ 		}
+  /******/ 		// Create a new module (and put it into the cache)
+  /******/ 		var module = __webpack_module_cache__[moduleId] = {
+  /******/ 			// no module.id needed
+  /******/ 			// no module.loaded needed
+  /******/ 			exports: {}
+  /******/ 		};
+  /******/ 	
+  /******/ 		// Execute the module function
+  /******/ 		var threw = true;
+  /******/ 		try {
+  /******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require3_);
+  /******/ 			threw = false;
+  /******/ 		} finally {
+  /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+  /******/ 		}
+  /******/ 	
+  /******/ 		// Return the exports of the module
+  /******/ 		return module.exports;
+  /******/ 	}
+  /******/ 	
+  /************************************************************************/
+  /******/ 	/* webpack/runtime/compat get default export */
+  /******/ 	(() => {
+  /******/ 		// getDefaultExport function for compatibility with non-harmony modules
+  /******/ 		__nccwpck_require3_.n = (module) => {
+  /******/ 			var getter = module && module.__esModule ?
+  /******/ 				() => (module['default']) :
+  /******/ 				() => (module);
+  /******/ 			__nccwpck_require3_.d(getter, { a: getter });
+  /******/ 			return getter;
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/define property getters */
+  /******/ 	(() => {
+  /******/ 		// define getter functions for harmony exports
+  /******/ 		__nccwpck_require3_.d = (exports, definition) => {
+  /******/ 			for(var key in definition) {
+  /******/ 				if(__nccwpck_require3_.o(definition, key) && !__nccwpck_require3_.o(exports, key)) {
+  /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+  /******/ 				}
+  /******/ 			}
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+  /******/ 	(() => {
+  /******/ 		__nccwpck_require3_.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/make namespace object */
+  /******/ 	(() => {
+  /******/ 		// define __esModule on exports
+  /******/ 		__nccwpck_require3_.r = (exports) => {
+  /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+  /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+  /******/ 			}
+  /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/compat */
+  /******/ 	
+  /******/ 	if (typeof __nccwpck_require3_ !== 'undefined') __nccwpck_require3_.ab = __dirname + "/";
+  /******/ 	
+  /************************************************************************/
+  var __webpack_exports__ = {};
+  // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+  (() => {
+  __nccwpck_require3_.r(__webpack_exports__);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require3_(622);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require3_.n(path__WEBPACK_IMPORTED_MODULE_0__);
+  
+  
+  const file = __nccwpck_require3_.ab + "pi-bridge.js";
+  
+  const obscureRequire = eval(`function obscureRequire (file) {
+      require(file);
+  }`);
+  
+  console.log(obscureRequire(__nccwpck_require3_.ab + "pi-bridge.js"));
+  
+  })();
+  
+  module.exports = __webpack_exports__;
+  /******/ })()
+  ;
+  
+
+/***/ }),
+
+/***/ 622:
+/***/ ((module) => {
+
+"use strict";
+module.exports = __nccwpck_require__(622);
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require2_(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require2_);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require2_ !== 'undefined') __nccwpck_require2_.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require2_(332);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;
+
+/***/ }),
+
+/***/ 622:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("path");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(39);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;

--- a/test/unit/nested-builds/input.js
+++ b/test/unit/nested-builds/input.js
@@ -1,0 +1,111 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 622:
+/***/ ((module) => {
+
+  module.exports = require("path");
+
+  /***/ })
+  
+  /******/ 	});
+  /************************************************************************/
+  /******/ 	// The module cache
+  /******/ 	var __webpack_module_cache__ = {};
+  /******/ 	
+  /******/ 	// The require function
+  /******/ 	function __nccwpck_require__(moduleId) {
+  /******/ 		// Check if module is in cache
+  /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+  /******/ 		if (cachedModule !== undefined) {
+  /******/ 			return cachedModule.exports;
+  /******/ 		}
+  /******/ 		// Create a new module (and put it into the cache)
+  /******/ 		var module = __webpack_module_cache__[moduleId] = {
+  /******/ 			// no module.id needed
+  /******/ 			// no module.loaded needed
+  /******/ 			exports: {}
+  /******/ 		};
+  /******/ 	
+  /******/ 		// Execute the module function
+  /******/ 		var threw = true;
+  /******/ 		try {
+  /******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+  /******/ 			threw = false;
+  /******/ 		} finally {
+  /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+  /******/ 		}
+  /******/ 	
+  /******/ 		// Return the exports of the module
+  /******/ 		return module.exports;
+  /******/ 	}
+  /******/ 	
+  /************************************************************************/
+  /******/ 	/* webpack/runtime/compat get default export */
+  /******/ 	(() => {
+  /******/ 		// getDefaultExport function for compatibility with non-harmony modules
+  /******/ 		__nccwpck_require__.n = (module) => {
+  /******/ 			var getter = module && module.__esModule ?
+  /******/ 				() => (module['default']) :
+  /******/ 				() => (module);
+  /******/ 			__nccwpck_require__.d(getter, { a: getter });
+  /******/ 			return getter;
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/define property getters */
+  /******/ 	(() => {
+  /******/ 		// define getter functions for harmony exports
+  /******/ 		__nccwpck_require__.d = (exports, definition) => {
+  /******/ 			for(var key in definition) {
+  /******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
+  /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+  /******/ 				}
+  /******/ 			}
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+  /******/ 	(() => {
+  /******/ 		__nccwpck_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/make namespace object */
+  /******/ 	(() => {
+  /******/ 		// define __esModule on exports
+  /******/ 		__nccwpck_require__.r = (exports) => {
+  /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+  /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+  /******/ 			}
+  /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/compat */
+  /******/ 	
+  /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+  /******/ 	
+  /************************************************************************/
+  var __webpack_exports__ = {};
+  // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+  (() => {
+  __nccwpck_require__.r(__webpack_exports__);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(622);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
+  
+  
+  const file = __nccwpck_require__.ab + "pi-bridge.js";
+  
+  const obscureRequire = eval(`function obscureRequire (file) {
+      require(file);
+  }`);
+  
+  console.log(obscureRequire(__nccwpck_require__.ab + "pi-bridge.js"));
+  
+  })();
+  
+  module.exports = __webpack_exports__;
+  /******/ })()
+  ;
+  

--- a/test/unit/nested-builds/output-coverage.js
+++ b/test/unit/nested-builds/output-coverage.js
@@ -1,0 +1,175 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 491:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 622:
+/***/ ((module) => {
+
+  module.exports = __nccwpck_require__(622);
+
+  /***/ })
+  
+  /******/ 	});
+  /************************************************************************/
+  /******/ 	// The module cache
+  /******/ 	var __webpack_module_cache__ = {};
+  /******/ 	
+  /******/ 	// The require function
+  /******/ 	function __nccwpck_require2_(moduleId) {
+  /******/ 		// Check if module is in cache
+  /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+  /******/ 		if (cachedModule !== undefined) {
+  /******/ 			return cachedModule.exports;
+  /******/ 		}
+  /******/ 		// Create a new module (and put it into the cache)
+  /******/ 		var module = __webpack_module_cache__[moduleId] = {
+  /******/ 			// no module.id needed
+  /******/ 			// no module.loaded needed
+  /******/ 			exports: {}
+  /******/ 		};
+  /******/ 	
+  /******/ 		// Execute the module function
+  /******/ 		var threw = true;
+  /******/ 		try {
+  /******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require2_);
+  /******/ 			threw = false;
+  /******/ 		} finally {
+  /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+  /******/ 		}
+  /******/ 	
+  /******/ 		// Return the exports of the module
+  /******/ 		return module.exports;
+  /******/ 	}
+  /******/ 	
+  /************************************************************************/
+  /******/ 	/* webpack/runtime/compat get default export */
+  /******/ 	(() => {
+  /******/ 		// getDefaultExport function for compatibility with non-harmony modules
+  /******/ 		__nccwpck_require2_.n = (module) => {
+  /******/ 			var getter = module && module.__esModule ?
+  /******/ 				() => (module['default']) :
+  /******/ 				() => (module);
+  /******/ 			__nccwpck_require2_.d(getter, { a: getter });
+  /******/ 			return getter;
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/define property getters */
+  /******/ 	(() => {
+  /******/ 		// define getter functions for harmony exports
+  /******/ 		__nccwpck_require2_.d = (exports, definition) => {
+  /******/ 			for(var key in definition) {
+  /******/ 				if(__nccwpck_require2_.o(definition, key) && !__nccwpck_require2_.o(exports, key)) {
+  /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+  /******/ 				}
+  /******/ 			}
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+  /******/ 	(() => {
+  /******/ 		__nccwpck_require2_.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/make namespace object */
+  /******/ 	(() => {
+  /******/ 		// define __esModule on exports
+  /******/ 		__nccwpck_require2_.r = (exports) => {
+  /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+  /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+  /******/ 			}
+  /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/compat */
+  /******/ 	
+  /******/ 	if (typeof __nccwpck_require2_ !== 'undefined') __nccwpck_require2_.ab = __dirname + "/";
+  /******/ 	
+  /************************************************************************/
+  var __webpack_exports__ = {};
+  // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+  (() => {
+  __nccwpck_require2_.r(__webpack_exports__);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require2_(622);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require2_.n(path__WEBPACK_IMPORTED_MODULE_0__);
+  
+  
+  const file = __nccwpck_require2_.ab + "pi-bridge.js";
+  
+  const obscureRequire = eval(`function obscureRequire (file) {
+      require(file);
+  }`);
+  
+  console.log(obscureRequire(__nccwpck_require2_.ab + "pi-bridge.js"));
+  
+  })();
+  
+  module.exports = __webpack_exports__;
+  /******/ })()
+  ;
+  
+
+/***/ }),
+
+/***/ 622:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("path");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(491);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;

--- a/test/unit/nested-builds/output.js
+++ b/test/unit/nested-builds/output.js
@@ -1,0 +1,175 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 332:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 622:
+/***/ ((module) => {
+
+  module.exports = __nccwpck_require__(622);
+
+  /***/ })
+  
+  /******/ 	});
+  /************************************************************************/
+  /******/ 	// The module cache
+  /******/ 	var __webpack_module_cache__ = {};
+  /******/ 	
+  /******/ 	// The require function
+  /******/ 	function __nccwpck_require2_(moduleId) {
+  /******/ 		// Check if module is in cache
+  /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+  /******/ 		if (cachedModule !== undefined) {
+  /******/ 			return cachedModule.exports;
+  /******/ 		}
+  /******/ 		// Create a new module (and put it into the cache)
+  /******/ 		var module = __webpack_module_cache__[moduleId] = {
+  /******/ 			// no module.id needed
+  /******/ 			// no module.loaded needed
+  /******/ 			exports: {}
+  /******/ 		};
+  /******/ 	
+  /******/ 		// Execute the module function
+  /******/ 		var threw = true;
+  /******/ 		try {
+  /******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require2_);
+  /******/ 			threw = false;
+  /******/ 		} finally {
+  /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+  /******/ 		}
+  /******/ 	
+  /******/ 		// Return the exports of the module
+  /******/ 		return module.exports;
+  /******/ 	}
+  /******/ 	
+  /************************************************************************/
+  /******/ 	/* webpack/runtime/compat get default export */
+  /******/ 	(() => {
+  /******/ 		// getDefaultExport function for compatibility with non-harmony modules
+  /******/ 		__nccwpck_require2_.n = (module) => {
+  /******/ 			var getter = module && module.__esModule ?
+  /******/ 				() => (module['default']) :
+  /******/ 				() => (module);
+  /******/ 			__nccwpck_require2_.d(getter, { a: getter });
+  /******/ 			return getter;
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/define property getters */
+  /******/ 	(() => {
+  /******/ 		// define getter functions for harmony exports
+  /******/ 		__nccwpck_require2_.d = (exports, definition) => {
+  /******/ 			for(var key in definition) {
+  /******/ 				if(__nccwpck_require2_.o(definition, key) && !__nccwpck_require2_.o(exports, key)) {
+  /******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+  /******/ 				}
+  /******/ 			}
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+  /******/ 	(() => {
+  /******/ 		__nccwpck_require2_.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/make namespace object */
+  /******/ 	(() => {
+  /******/ 		// define __esModule on exports
+  /******/ 		__nccwpck_require2_.r = (exports) => {
+  /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+  /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+  /******/ 			}
+  /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+  /******/ 		};
+  /******/ 	})();
+  /******/ 	
+  /******/ 	/* webpack/runtime/compat */
+  /******/ 	
+  /******/ 	if (typeof __nccwpck_require2_ !== 'undefined') __nccwpck_require2_.ab = __dirname + "/";
+  /******/ 	
+  /************************************************************************/
+  var __webpack_exports__ = {};
+  // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+  (() => {
+  __nccwpck_require2_.r(__webpack_exports__);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require2_(622);
+  /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require2_.n(path__WEBPACK_IMPORTED_MODULE_0__);
+  
+  
+  const file = __nccwpck_require2_.ab + "pi-bridge.js";
+  
+  const obscureRequire = eval(`function obscureRequire (file) {
+      require(file);
+  }`);
+  
+  console.log(obscureRequire(__nccwpck_require2_.ab + "pi-bridge.js"));
+  
+  })();
+  
+  module.exports = __webpack_exports__;
+  /******/ })()
+  ;
+  
+
+/***/ }),
+
+/***/ 622:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("path");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(332);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;


### PR DESCRIPTION
This fixes the `__nccwpck_require__` handling to ensure conflicts are avoided when running against a build that already has an `__nccpck_require__` identifier. It uses numbering up to 9 given the limited space. We can look at increasing this limit in future though.