### PR TITLE
Fix `compilerOptions` from `tsconfig.json`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ function ncc (
   // add TsconfigPathsPlugin to support `paths` resolution in tsconfig
   // we need to catch here because the plugin will
   // error if there's no tsconfig in the working directory
-  let fullTsconfig;
+  let fullTsconfig = {};
   try {
     const tsconfig = tsconfigPaths.loadConfig();
     fullTsconfig = loadTsconfig(tsconfig.configFileAbsolutePath) || {
@@ -334,9 +334,8 @@ function ncc (
               transpileOnly,
               compiler: eval('__dirname + "/typescript.js"'),
               compilerOptions: {
+                ...fullTsconfig.compilerOptions,
                 allowSyntheticDefaultImports: true,
-                incremental: fullTsconfig?.compilerOptions?.incremental ?? false,
-                module: fullTsconfig?.compilerOptions?.module ?? 'esnext',
                 noEmit: false,
                 outDir: '//'
               }

--- a/src/index.js
+++ b/src/index.js
@@ -334,6 +334,7 @@ function ncc (
               transpileOnly,
               compiler: eval('__dirname + "/typescript.js"'),
               compilerOptions: {
+                module: 'esnext'
                 ...fullTsconfig.compilerOptions,
                 allowSyntheticDefaultImports: true,
                 noEmit: false,

--- a/src/index.js
+++ b/src/index.js
@@ -335,14 +335,10 @@ function ncc (
               compiler: eval('__dirname + "/typescript.js"'),
               compilerOptions: {
                 allowSyntheticDefaultImports: true,
-                module: 'esnext',
-                outDir: '//',
-                ...(fullTsconfig &&
-                  fullTsconfig.compilerOptions &&
-                  fullTsconfig.compilerOptions.incremental
-                    ? { incremental: false }
-                    : {}),
-                noEmit: false
+                incremental: fullTsconfig?.compilerOptions?.incremental ?? false,
+                module: fullTsconfig?.compilerOptions?.module ?? 'esnext',
+                noEmit: false,
+                outDir: '//'
               }
             }
           }]

--- a/src/index.js
+++ b/src/index.js
@@ -334,7 +334,8 @@ function ncc (
               transpileOnly,
               compiler: eval('__dirname + "/typescript.js"'),
               compilerOptions: {
-                module: 'esnext'
+                module: 'esnext',
+                target: 'esnext',
                 ...fullTsconfig.compilerOptions,
                 allowSyntheticDefaultImports: true,
                 noEmit: false,

--- a/test/unit/bundle-subasset2/output-coverage.js
+++ b/test/unit/bundle-subasset2/output-coverage.js
@@ -88,60 +88,14 @@ var external_piscina_default = /*#__PURE__*/__nccwpck_require__.n(external_pisci
 ;// CONCATENATED MODULE: external "path"
 const external_path_namespaceObject = require("path");
 ;// CONCATENATED MODULE: ./test/unit/bundle-subasset2/input.ts
-var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __generator = (undefined && undefined.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
-    }
-};
 
 
-var piscina = new (external_piscina_default())({
+const piscina = new (external_piscina_default())({
     filename: __nccwpck_require__.ab + "pi-bridge.js",
 });
-(function () {
-    return __awaiter(this, void 0, void 0, function () {
-        var result;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, piscina.runTask(2)];
-                case 1:
-                    result = _a.sent();
-                    console.log(result);
-                    return [2 /*return*/];
-            }
-        });
-    });
+(async function () {
+    const result = await piscina.runTask(2);
+    console.log(result);
 })();
 
 module.exports = __webpack_exports__;

--- a/test/unit/bundle-subasset2/output.js
+++ b/test/unit/bundle-subasset2/output.js
@@ -88,60 +88,14 @@ var external_piscina_default = /*#__PURE__*/__nccwpck_require__.n(external_pisci
 ;// CONCATENATED MODULE: external "path"
 const external_path_namespaceObject = require("path");
 ;// CONCATENATED MODULE: ./test/unit/bundle-subasset2/input.ts
-var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __generator = (undefined && undefined.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
-    }
-};
 
 
-var piscina = new (external_piscina_default())({
+const piscina = new (external_piscina_default())({
     filename: __nccwpck_require__.ab + "pi-bridge.js",
 });
-(function () {
-    return __awaiter(this, void 0, void 0, function () {
-        var result;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, piscina.runTask(2)];
-                case 1:
-                    result = _a.sent();
-                    console.log(result);
-                    return [2 /*return*/];
-            }
-        });
-    });
+(async function () {
+    const result = await piscina.runTask(2);
+    console.log(result);
 })();
 
 module.exports = __webpack_exports__;

--- a/test/unit/ts-exts/output-coverage.js
+++ b/test/unit/ts-exts/output-coverage.js
@@ -1,38 +1,77 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __nccwpck_require__ = {};
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 119:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.default = {};
+
+
+/***/ }),
+
+/***/ 43:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.default = void 0;
+var dep_dep_js_1 = __nccwpck_require__(119);
+Object.defineProperty(exports, "default", ({ enumerable: true, get: function () { return dep_dep_js_1.default; } }));
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/make namespace object */
-/******/ 	(() => {
-/******/ 		// define __esModule on exports
-/******/ 		__nccwpck_require__.r = (exports) => {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
-/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 		};
-/******/ 	})();
-/******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-// ESM COMPAT FLAG
-__nccwpck_require__.r(__webpack_exports__);
+// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+(() => {
+var exports = __webpack_exports__;
 
-;// CONCATENATED MODULE: ./test/unit/ts-exts/dep-dep.ts
-/* harmony default export */ const dep_dep = ({});
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const dep_js_1 = __nccwpck_require__(43);
+console.log(dep_js_1.default);
 
-;// CONCATENATED MODULE: ./test/unit/ts-exts/dep.ts
-
-
-;// CONCATENATED MODULE: ./test/unit/ts-exts/input.ts
-
-console.log(dep_dep);
+})();
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/test/unit/ts-mixed-modules/input.ts
+++ b/test/unit/ts-mixed-modules/input.ts
@@ -1,0 +1,7 @@
+import { Config } from './types'
+
+const config: Config = {
+  routes: ['/foo']
+};
+
+module.exports = config;

--- a/test/unit/ts-mixed-modules/output-coverage.js
+++ b/test/unit/ts-mixed-modules/output-coverage.js
@@ -1,0 +1,94 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 119:
+/***/ ((module, __webpack_exports__, __nccwpck_require__) => {
+
+    __nccwpck_require__.r(__webpack_exports__);
+    /* module decorator */ module = __nccwpck_require__.hmd(module);
+    const config = {
+        routes: ['/foo']
+    };
+    module.exports = config;
+    
+    
+    
+    /***/ })
+    
+    /******/ 	});
+    /************************************************************************/
+    /******/ 	// The module cache
+    /******/ 	var __webpack_module_cache__ = {};
+    /******/ 	
+    /******/ 	// The require function
+    /******/ 	function __nccwpck_require__(moduleId) {
+    /******/ 		// Check if module is in cache
+    /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+    /******/ 		if (cachedModule !== undefined) {
+    /******/ 			return cachedModule.exports;
+    /******/ 		}
+    /******/ 		// Create a new module (and put it into the cache)
+    /******/ 		var module = __webpack_module_cache__[moduleId] = {
+    /******/ 			id: moduleId,
+    /******/ 			loaded: false,
+    /******/ 			exports: {}
+    /******/ 		};
+    /******/ 	
+    /******/ 		// Execute the module function
+    /******/ 		var threw = true;
+    /******/ 		try {
+    /******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+    /******/ 			threw = false;
+    /******/ 		} finally {
+    /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+    /******/ 		}
+    /******/ 	
+    /******/ 		// Flag the module as loaded
+    /******/ 		module.loaded = true;
+    /******/ 	
+    /******/ 		// Return the exports of the module
+    /******/ 		return module.exports;
+    /******/ 	}
+    /******/ 	
+    /************************************************************************/
+    /******/ 	/* webpack/runtime/harmony module decorator */
+    /******/ 	(() => {
+    /******/ 		__nccwpck_require__.hmd = (module) => {
+    /******/ 			module = Object.create(module);
+    /******/ 			if (!module.children) module.children = [];
+    /******/ 			Object.defineProperty(module, 'exports', {
+    /******/ 				enumerable: true,
+    /******/ 				set: () => {
+    /******/ 					throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);
+    /******/ 				}
+    /******/ 			});
+    /******/ 			return module;
+    /******/ 		};
+    /******/ 	})();
+    /******/ 	
+    /******/ 	/* webpack/runtime/make namespace object */
+    /******/ 	(() => {
+    /******/ 		// define __esModule on exports
+    /******/ 		__nccwpck_require__.r = (exports) => {
+    /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+    /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+    /******/ 			}
+    /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+    /******/ 		};
+    /******/ 	})();
+    /******/ 	
+    /******/ 	/* webpack/runtime/compat */
+    /******/ 	
+    /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+    /******/ 	
+    /************************************************************************/
+    /******/ 	
+    /******/ 	// startup
+    /******/ 	// Load entry module and return exports
+    /******/ 	// This entry module is referenced by other modules so it can't be inlined
+    /******/ 	var __webpack_exports__ = __nccwpck_require__(119);
+    /******/ 	module.exports = __webpack_exports__;
+    /******/ 	
+    /******/ })()
+    ;

--- a/test/unit/ts-mixed-modules/output-coverage.js
+++ b/test/unit/ts-mixed-modules/output-coverage.js
@@ -2,93 +2,63 @@
 /******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 119:
-/***/ ((module, __webpack_exports__, __nccwpck_require__) => {
+/***/ 866:
+/***/ ((module, exports) => {
 
-    __nccwpck_require__.r(__webpack_exports__);
-    /* module decorator */ module = __nccwpck_require__.hmd(module);
-    const config = {
-        routes: ['/foo']
-    };
-    module.exports = config;
-    
-    
-    
-    /***/ })
-    
-    /******/ 	});
-    /************************************************************************/
-    /******/ 	// The module cache
-    /******/ 	var __webpack_module_cache__ = {};
-    /******/ 	
-    /******/ 	// The require function
-    /******/ 	function __nccwpck_require__(moduleId) {
-    /******/ 		// Check if module is in cache
-    /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
-    /******/ 		if (cachedModule !== undefined) {
-    /******/ 			return cachedModule.exports;
-    /******/ 		}
-    /******/ 		// Create a new module (and put it into the cache)
-    /******/ 		var module = __webpack_module_cache__[moduleId] = {
-    /******/ 			id: moduleId,
-    /******/ 			loaded: false,
-    /******/ 			exports: {}
-    /******/ 		};
-    /******/ 	
-    /******/ 		// Execute the module function
-    /******/ 		var threw = true;
-    /******/ 		try {
-    /******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
-    /******/ 			threw = false;
-    /******/ 		} finally {
-    /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
-    /******/ 		}
-    /******/ 	
-    /******/ 		// Flag the module as loaded
-    /******/ 		module.loaded = true;
-    /******/ 	
-    /******/ 		// Return the exports of the module
-    /******/ 		return module.exports;
-    /******/ 	}
-    /******/ 	
-    /************************************************************************/
-    /******/ 	/* webpack/runtime/harmony module decorator */
-    /******/ 	(() => {
-    /******/ 		__nccwpck_require__.hmd = (module) => {
-    /******/ 			module = Object.create(module);
-    /******/ 			if (!module.children) module.children = [];
-    /******/ 			Object.defineProperty(module, 'exports', {
-    /******/ 				enumerable: true,
-    /******/ 				set: () => {
-    /******/ 					throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);
-    /******/ 				}
-    /******/ 			});
-    /******/ 			return module;
-    /******/ 		};
-    /******/ 	})();
-    /******/ 	
-    /******/ 	/* webpack/runtime/make namespace object */
-    /******/ 	(() => {
-    /******/ 		// define __esModule on exports
-    /******/ 		__nccwpck_require__.r = (exports) => {
-    /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-    /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-    /******/ 			}
-    /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-    /******/ 		};
-    /******/ 	})();
-    /******/ 	
-    /******/ 	/* webpack/runtime/compat */
-    /******/ 	
-    /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-    /******/ 	
-    /************************************************************************/
-    /******/ 	
-    /******/ 	// startup
-    /******/ 	// Load entry module and return exports
-    /******/ 	// This entry module is referenced by other modules so it can't be inlined
-    /******/ 	var __webpack_exports__ = __nccwpck_require__(119);
-    /******/ 	module.exports = __webpack_exports__;
-    /******/ 	
-    /******/ })()
-    ;
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const config = {
+    routes: ['/foo']
+};
+module.exports = config;
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(866);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;

--- a/test/unit/ts-mixed-modules/output.js
+++ b/test/unit/ts-mixed-modules/output.js
@@ -1,0 +1,94 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 119:
+/***/ ((module, __webpack_exports__, __nccwpck_require__) => {
+
+    __nccwpck_require__.r(__webpack_exports__);
+    /* module decorator */ module = __nccwpck_require__.hmd(module);
+    const config = {
+        routes: ['/foo']
+    };
+    module.exports = config;
+    
+    
+    
+    /***/ })
+    
+    /******/ 	});
+    /************************************************************************/
+    /******/ 	// The module cache
+    /******/ 	var __webpack_module_cache__ = {};
+    /******/ 	
+    /******/ 	// The require function
+    /******/ 	function __nccwpck_require__(moduleId) {
+    /******/ 		// Check if module is in cache
+    /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+    /******/ 		if (cachedModule !== undefined) {
+    /******/ 			return cachedModule.exports;
+    /******/ 		}
+    /******/ 		// Create a new module (and put it into the cache)
+    /******/ 		var module = __webpack_module_cache__[moduleId] = {
+    /******/ 			id: moduleId,
+    /******/ 			loaded: false,
+    /******/ 			exports: {}
+    /******/ 		};
+    /******/ 	
+    /******/ 		// Execute the module function
+    /******/ 		var threw = true;
+    /******/ 		try {
+    /******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+    /******/ 			threw = false;
+    /******/ 		} finally {
+    /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+    /******/ 		}
+    /******/ 	
+    /******/ 		// Flag the module as loaded
+    /******/ 		module.loaded = true;
+    /******/ 	
+    /******/ 		// Return the exports of the module
+    /******/ 		return module.exports;
+    /******/ 	}
+    /******/ 	
+    /************************************************************************/
+    /******/ 	/* webpack/runtime/harmony module decorator */
+    /******/ 	(() => {
+    /******/ 		__nccwpck_require__.hmd = (module) => {
+    /******/ 			module = Object.create(module);
+    /******/ 			if (!module.children) module.children = [];
+    /******/ 			Object.defineProperty(module, 'exports', {
+    /******/ 				enumerable: true,
+    /******/ 				set: () => {
+    /******/ 					throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);
+    /******/ 				}
+    /******/ 			});
+    /******/ 			return module;
+    /******/ 		};
+    /******/ 	})();
+    /******/ 	
+    /******/ 	/* webpack/runtime/make namespace object */
+    /******/ 	(() => {
+    /******/ 		// define __esModule on exports
+    /******/ 		__nccwpck_require__.r = (exports) => {
+    /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+    /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+    /******/ 			}
+    /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+    /******/ 		};
+    /******/ 	})();
+    /******/ 	
+    /******/ 	/* webpack/runtime/compat */
+    /******/ 	
+    /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+    /******/ 	
+    /************************************************************************/
+    /******/ 	
+    /******/ 	// startup
+    /******/ 	// Load entry module and return exports
+    /******/ 	// This entry module is referenced by other modules so it can't be inlined
+    /******/ 	var __webpack_exports__ = __nccwpck_require__(119);
+    /******/ 	module.exports = __webpack_exports__;
+    /******/ 	
+    /******/ })()
+    ;

--- a/test/unit/ts-mixed-modules/output.js
+++ b/test/unit/ts-mixed-modules/output.js
@@ -5,90 +5,90 @@
 /***/ 119:
 /***/ ((module, __webpack_exports__, __nccwpck_require__) => {
 
-    __nccwpck_require__.r(__webpack_exports__);
-    /* module decorator */ module = __nccwpck_require__.hmd(module);
-    const config = {
-        routes: ['/foo']
-    };
-    module.exports = config;
-    
-    
-    
-    /***/ })
-    
-    /******/ 	});
-    /************************************************************************/
-    /******/ 	// The module cache
-    /******/ 	var __webpack_module_cache__ = {};
-    /******/ 	
-    /******/ 	// The require function
-    /******/ 	function __nccwpck_require__(moduleId) {
-    /******/ 		// Check if module is in cache
-    /******/ 		var cachedModule = __webpack_module_cache__[moduleId];
-    /******/ 		if (cachedModule !== undefined) {
-    /******/ 			return cachedModule.exports;
-    /******/ 		}
-    /******/ 		// Create a new module (and put it into the cache)
-    /******/ 		var module = __webpack_module_cache__[moduleId] = {
-    /******/ 			id: moduleId,
-    /******/ 			loaded: false,
-    /******/ 			exports: {}
-    /******/ 		};
-    /******/ 	
-    /******/ 		// Execute the module function
-    /******/ 		var threw = true;
-    /******/ 		try {
-    /******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
-    /******/ 			threw = false;
-    /******/ 		} finally {
-    /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
-    /******/ 		}
-    /******/ 	
-    /******/ 		// Flag the module as loaded
-    /******/ 		module.loaded = true;
-    /******/ 	
-    /******/ 		// Return the exports of the module
-    /******/ 		return module.exports;
-    /******/ 	}
-    /******/ 	
-    /************************************************************************/
-    /******/ 	/* webpack/runtime/harmony module decorator */
-    /******/ 	(() => {
-    /******/ 		__nccwpck_require__.hmd = (module) => {
-    /******/ 			module = Object.create(module);
-    /******/ 			if (!module.children) module.children = [];
-    /******/ 			Object.defineProperty(module, 'exports', {
-    /******/ 				enumerable: true,
-    /******/ 				set: () => {
-    /******/ 					throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);
-    /******/ 				}
-    /******/ 			});
-    /******/ 			return module;
-    /******/ 		};
-    /******/ 	})();
-    /******/ 	
-    /******/ 	/* webpack/runtime/make namespace object */
-    /******/ 	(() => {
-    /******/ 		// define __esModule on exports
-    /******/ 		__nccwpck_require__.r = (exports) => {
-    /******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-    /******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-    /******/ 			}
-    /******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-    /******/ 		};
-    /******/ 	})();
-    /******/ 	
-    /******/ 	/* webpack/runtime/compat */
-    /******/ 	
-    /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
-    /******/ 	
-    /************************************************************************/
-    /******/ 	
-    /******/ 	// startup
-    /******/ 	// Load entry module and return exports
-    /******/ 	// This entry module is referenced by other modules so it can't be inlined
-    /******/ 	var __webpack_exports__ = __nccwpck_require__(119);
-    /******/ 	module.exports = __webpack_exports__;
-    /******/ 	
-    /******/ })()
-    ;
+__nccwpck_require__.r(__webpack_exports__);
+/* module decorator */ module = __nccwpck_require__.hmd(module);
+const config = {
+    routes: ['/foo']
+};
+module.exports = config;
+
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			id: moduleId,
+/******/ 			loaded: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/harmony module decorator */
+/******/ 	(() => {
+/******/ 		__nccwpck_require__.hmd = (module) => {
+/******/ 			module = Object.create(module);
+/******/ 			if (!module.children) module.children = [];
+/******/ 			Object.defineProperty(module, 'exports', {
+/******/ 				enumerable: true,
+/******/ 				set: () => {
+/******/ 					throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);
+/******/ 				}
+/******/ 			});
+/******/ 			return module;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__nccwpck_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(119);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;

--- a/test/unit/ts-mixed-modules/tsconfig.json
+++ b/test/unit/ts-mixed-modules/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+      "baseUrl": ".",
+      "esModuleInterop": true,
+      "lib": ["esnext"],
+      "module": "commonjs",
+      "moduleResolution": "node",
+      "outDir": "dist",
+      "strict": true,
+      "target": "es2020"
+    }
+  }

--- a/test/unit/ts-mixed-modules/types.ts
+++ b/test/unit/ts-mixed-modules/types.ts
@@ -1,0 +1,3 @@
+export interface Config {
+  routes: string[];
+}

--- a/test/unit/tsconfig-paths-allowjs/output-coverage.js
+++ b/test/unit/tsconfig-paths-allowjs/output-coverage.js
@@ -1,9 +1,69 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __nccwpck_require__ = {};
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 306:
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
+
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */ });
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ({});
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__nccwpck_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/make namespace object */
 /******/ 	(() => {
 /******/ 		// define __esModule on exports
@@ -21,15 +81,15 @@
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-// ESM COMPAT FLAG
-__nccwpck_require__.r(__webpack_exports__);
+// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+(() => {
+var exports = __webpack_exports__;
 
-;// CONCATENATED MODULE: ./test/unit/tsconfig-paths-allowjs/module.js
-/* harmony default export */ const tsconfig_paths_allowjs_module = ({});
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const _module_1 = __nccwpck_require__(306);
+console.log(_module_1.default);
 
-;// CONCATENATED MODULE: ./test/unit/tsconfig-paths-allowjs/input.ts
-
-console.log(tsconfig_paths_allowjs_module);
+})();
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
+++ b/test/unit/tsconfig-paths-conflicting-external/output-coverage.js
@@ -1,35 +1,65 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __nccwpck_require__ = {};
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 775:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.default = {};
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/make namespace object */
-/******/ 	(() => {
-/******/ 		// define __esModule on exports
-/******/ 		__nccwpck_require__.r = (exports) => {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
-/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 		};
-/******/ 	})();
-/******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-// ESM COMPAT FLAG
-__nccwpck_require__.r(__webpack_exports__);
+// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+(() => {
+var exports = __webpack_exports__;
 
-;// CONCATENATED MODULE: ./test/unit/tsconfig-paths-conflicting-external/module.ts
-/* harmony default export */ const tsconfig_paths_conflicting_external_module = ({});
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const _module_1 = __nccwpck_require__(775);
+console.log(_module_1.default);
 
-;// CONCATENATED MODULE: ./test/unit/tsconfig-paths-conflicting-external/input.ts
-
-console.log(tsconfig_paths_conflicting_external_module);
+})();
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/test/unit/tsconfig-paths/output-coverage.js
+++ b/test/unit/tsconfig-paths/output-coverage.js
@@ -1,35 +1,65 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
-/******/ 	// The require scope
-/******/ 	var __nccwpck_require__ = {};
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 520:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.default = {};
+
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
 /******/ 	
 /************************************************************************/
-/******/ 	/* webpack/runtime/make namespace object */
-/******/ 	(() => {
-/******/ 		// define __esModule on exports
-/******/ 		__nccwpck_require__.r = (exports) => {
-/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
-/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
-/******/ 			}
-/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
-/******/ 		};
-/******/ 	})();
-/******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-// ESM COMPAT FLAG
-__nccwpck_require__.r(__webpack_exports__);
+// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+(() => {
+var exports = __webpack_exports__;
 
-;// CONCATENATED MODULE: ./test/unit/tsconfig-paths/module.ts
-/* harmony default export */ const tsconfig_paths_module = ({});
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const _module_1 = __nccwpck_require__(520);
+console.log(_module_1.default);
 
-;// CONCATENATED MODULE: ./test/unit/tsconfig-paths/input.ts
-
-console.log(tsconfig_paths_module);
+})();
 
 module.exports = __webpack_exports__;
 /******/ })()


### PR DESCRIPTION
This will make sure we pass `tsconfig.json` to the loader.

In particular the `module: commonjs` option is important to ensure mixed module usage like `tsc` supports.

Fixes #765