### PR TITLE
fix: use sha instead of deprecated md5 for hash algorithm

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -218,7 +218,7 @@ async function runCmd (argv, stdout, stderr) {
 
       outDir = resolve(
         require("os").tmpdir(),
-        crypto.createHash('sha').update(resolve(args._[1] || ".")).digest('hex')
+        crypto.createHash('sha256').update(resolve(args._[1] || ".")).digest('hex')
       );
       if (existsSync(outDir))
         rimraf.sync(outDir);

--- a/src/cli.js
+++ b/src/cli.js
@@ -218,7 +218,7 @@ async function runCmd (argv, stdout, stderr) {
 
       outDir = resolve(
         require("os").tmpdir(),
-        crypto.createHash('md5').update(resolve(args._[1] || ".")).digest('hex')
+        crypto.createHash('sha').update(resolve(args._[1] || ".")).digest('hex')
       );
       if (existsSync(outDir))
         rimraf.sync(outDir);

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const SUPPORTED_EXTENSIONS = [".js", ".json", ".node", ".mjs", ".ts", ".tsx"];
 
 const hashOf = name => {
   return crypto
-		.createHash("sha")
+		.createHash("sha256")
 		.update(name)
 		.digest("hex")
 		.slice(0, 10);

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const SUPPORTED_EXTENSIONS = [".js", ".json", ".node", ".mjs", ".ts", ".tsx"];
 
 const hashOf = name => {
   return crypto
-		.createHash("md4")
+		.createHash("sha")
 		.update(name)
 		.digest("hex")
 		.slice(0, 10);
@@ -174,13 +174,13 @@ function ncc (
     function get(key) {
       if (aliasMap.has(key)) return aliasMap.get(key);
       if (regexCache.has(key)) return regexCache.get(key);
-      
+
       for (const regex of regexps) {
         const matches = key.match(regex)
-        
+
         if (matches) {
           let result = aliasMap.get(regex)
-          
+
           if (matches.length > 1) {
             // allow using match from regex in result
             // e.g. caniuse-lite(/.*) -> caniuse-lite$1


### PR DESCRIPTION
OpenSSL deprecates and fully removes "md5" as a hash algorithm. This pull request replaces references to "md5" with "sha".

This should resolve the `ERR_OSSL_EVP_UNSUPPORTED` errors.

Should theoretically fix #805 but I am unable to get tests to pass locally, which seems unrelated.