### PR TITLE
chore: bump webpack-asset-relocator-loader to 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@sentry/node": "^6.10.0",
     "@slack/web-api": "^6.3.0",
     "@tensorflow/tfjs-node": "^3.12.0",
-    "@vercel/webpack-asset-relocator-loader": "1.7.0",
+    "@vercel/webpack-asset-relocator-loader": "1.7.2",
     "analytics-node": "^6.0.0",
     "apollo-server-express": "^2.2.2",
     "arg": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2536,10 +2536,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vercel/webpack-asset-relocator-loader@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.0.tgz#d3b707e0aba3111719f941dacb2408eff3c27319"
-  integrity sha512-1Dy3BdOliDwxA7VZSIg55E1d/us2KvsCQOZV25fgufG//CsnZBGiSAL7qewTQf7YVHH0A9PHgzwMmKIZ8aFYVw==
+"@vercel/webpack-asset-relocator-loader@1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.2.tgz#0210abd8d53b2799d53156dd0c18a4ef4e3b51cb"
+  integrity sha512-pdMwUawmAtH/LScbjKJq/y2+gZFggFMc2tlJrlPSrgKajvYPEis3L9QKcMyC9RN1Xos4ezAP5AJfRCNN6RMKCQ==
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"


### PR DESCRIPTION
- Related to #593 
- Related to https://github.com/vercel/webpack-asset-relocator-loader/pull/153