### PR TITLE
add `--tsconfig-path` option for CLI & support `extends` property in `tsconfig.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "node-gyp": "^8.4.1",
     "npm": "^6.13.4",
     "oracledb": "^4.2.0",
+    "param-case": "^3.0.4",
     "passport": "^0.5.2",
     "passport-google-oauth": "^2.0.0",
     "path-platform": "^0.11.15",

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ Outputs the Node.js compact build of `input.js` into `dist/index.js`.
   --license [file]         Adds a file containing licensing information to the output
   --stats-out [file]       Emit webpack stats as json to the specified output file
   --target [es]            ECMAScript target to use for output (default: es2015)
+  --tsconfig-path [file]   Specify tsconfig.json to use for build (default: resolve tsconfig.json from entrypoint)
                            Learn more: https://webpack.js.org/configuration/target
   -d, --debug              Show debug logs
 ```

--- a/src/cli.js
+++ b/src/cli.js
@@ -37,6 +37,7 @@ Options:
   --license [file]         Adds a file containing licensing information to the output
   --stats-out [file]       Emit webpack stats as json to the specified output file
   --target [es]            ECMAScript target to use for output (default: es2015)
+  --tsconfig-path [file]   Specify tsconfig.json to use for build (default: resolve tsconfig.json from entrypoint)
                            Learn more: https://webpack.js.org/configuration/target
   -d, --debug              Show debug logs
 `;
@@ -154,7 +155,8 @@ async function runCmd (argv, stdout, stderr) {
       "-t": "--transpile-only",
       "--license": String,
       "--stats-out": String,
-      "--target": String
+      "--target": String,
+      "--tsconfig-path": String
     }, {
       permissive: false,
       argv
@@ -250,7 +252,8 @@ async function runCmd (argv, stdout, stderr) {
           transpileOnly: args["--transpile-only"],
           license: args["--license"],
           quiet,
-          target: args["--target"]
+          target: args["--target"],
+          tsconfigPath: args["--tsconfig-path"]
         }
       );
 

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,8 @@ function ncc (
     production = true,
     // webpack defaults to `module` and `main`, but that's
     // not really what node.js supports, so we reset it
-    mainFields = ['main']
+    mainFields = ['main'],
+    tsconfigPath = undefined
   } = {}
 ) {
   // v8 cache not supported for ES modules
@@ -108,7 +109,7 @@ function ncc (
     existingAssetNames.push(`${filename}.cache`);
     existingAssetNames.push(`${filename}.cache${ext}`);
   }
-  const compilerOptions = loadTsconfigOptions({
+  const compilerOptions = loadTsconfigOptions(tsconfigPath, {
     base: process.cwd(),
     start: dirname(entry),
     filename: 'tsconfig.json'

--- a/src/utils/load-tsconfig-options.js
+++ b/src/utils/load-tsconfig-options.js
@@ -1,0 +1,55 @@
+const ts = require('typescript');
+const { join, dirname } = require('path');
+const fs = require('fs');
+
+/**
+ * @typedef {object} LoadTsconfigInit
+ * @property {string} base
+ * @property {string} start
+ * @property {string} filename
+ */
+
+/**
+ * @description Adapted from https://github.com/vercel/vercel/blob/18bec983aefbe2a77bd14eda6fca59ff7e956d8b/packages/build-utils/src/fs/run-user-scripts.ts#L289-L310
+ * @param {LoadTsconfigInit}
+ * @returns {string | null}
+ */
+function walkParentDirs({
+  base,
+  start,
+  filename,
+}) {
+  let parent = '';
+
+  for (let current = start; base.length <= current.length; current = parent) {
+    const fullPath = join(current, filename);
+
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+
+    parent = dirname(current);
+  }
+
+  return null;
+}
+
+/**
+ * @param {LoadTsconfigInit}
+ * @returns {ts.CompilerOptions}
+ */
+exports.loadTsconfigOptions = function ({
+  base,
+  start,
+  filename,
+}) {
+  const tsconfig = walkParentDirs({ base, start, filename });
+  if (tsconfig == null) {
+    return {};
+  }
+  const content = ts.readConfigFile(tsconfig, ts.sys.readFile);
+  if (content.error != null || content.config == null) {
+    return {};
+  }
+  return ts.parseJsonConfigFileContent(content.config, ts.sys, dirname(tsconfig)).options;
+};

--- a/src/utils/load-tsconfig-options.js
+++ b/src/utils/load-tsconfig-options.js
@@ -1,5 +1,5 @@
 const ts = require('typescript');
-const { join, dirname } = require('path');
+const { join, dirname, resolve } = require('path');
 const fs = require('fs');
 
 /**
@@ -35,15 +35,17 @@ function walkParentDirs({
 }
 
 /**
+ * @param {string | undefined} configPath
  * @param {LoadTsconfigInit}
  * @returns {ts.CompilerOptions}
  */
-exports.loadTsconfigOptions = function ({
+exports.loadTsconfigOptions = function (configPath, {
   base,
   start,
   filename,
 }) {
-  const tsconfig = walkParentDirs({ base, start, filename });
+  // throw error if `configPath` does not exist
+  const tsconfig = configPath != null ? resolve(configPath) : walkParentDirs({ base, start, filename });
   if (tsconfig == null) {
     return {};
   }

--- a/test/cli.js
+++ b/test/cli.js
@@ -71,6 +71,16 @@ module.exports = [
     expect: { code: 0 }
   },
   {
+    args: ["run", "test/fixtures/ts-extends/any-args.ts"],
+    expect (code, stdout, stderr) {
+      return code === 1 && stderr.toString().indexOf('any-args.ts(4,20)') !== -1 && stderr.toString().indexOf('TS7006') !== -1;
+    }
+  },
+  {
+    args: ["run", "test/fixtures/ts-extends/any-args.ts", "--tsconfig-path", "test/fixtures/ts-extends/tsconfig.build.json"],
+    expect: { code: 0 }
+  },
+  {
     args: ["build", "-o", "tmp", "test/fixtures/test.cjs"],
     expect (code, stdout, stderr) {
       return stdout.toString().indexOf(join('tmp', 'index.cjs')) !== -1;

--- a/test/fixtures/ts-extends/any-args.ts
+++ b/test/fixtures/ts-extends/any-args.ts
@@ -1,0 +1,6 @@
+/**
+ * throws error (TS7006: an implicit 'any' type) if strict options is set to true, or otherwise passes compilation
+ */
+function something(args) {
+  return args;
+}

--- a/test/fixtures/ts-extends/tsconfig.build.json
+++ b/test/fixtures/ts-extends/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": false
+  }
+}

--- a/test/fixtures/ts-extends/tsconfig.json
+++ b/test/fixtures/ts-extends/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5512,6 +5512,14 @@ dot-case@^1.1.0:
   dependencies:
     sentence-case "^1.1.2"
 
+dot-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
+  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+
 dot-prop@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
@@ -9941,6 +9949,13 @@ lower-case@^1.1.0, lower-case@^1.1.1, lower-case@^1.1.2:
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
   integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
 
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  dependencies:
+    tslib "^2.0.3"
+
 lowercase-keys@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
@@ -10746,6 +10761,14 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+  dependencies:
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
 
 node-abi@^2.21.0:
   version "2.30.0"
@@ -11710,6 +11733,14 @@ param-case@^1.1.0:
   integrity sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=
   dependencies:
     sentence-case "^1.1.2"
+
+param-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
+  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 parents@^1.0.0, parents@^1.0.1:
   version "1.0.1"
@@ -14860,6 +14891,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@^2.0.3:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Overview

Hi, there!
I've made a PR to add a new CLI option and resolve potential problems. If there is something wrong or missing, feel free to point it out.
Thank you.

## Changes

- add `--tsconfig-path` to specify path to `tsconfig.json` file for CLI option
  - if path to `tsconfig.json` is passed by this option, ncc sees that path directly, or if not, ncc resolve path to `tsconfig.json` as before
- support `extends` property in `tsconfig.json`
  - use officially provided API by TypeScript to resolve and parse `compilerOptions` & `extends` property
  - add [param-case](https://www.npmjs.com/package/param-case) to convert values at `jsx` option to kebab-case


## Related

- resolve #457
