### PR TITLE
CI: Add Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [14, 16]
+        node: [14, 16, 18]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Cancel Previous Runs


### PR DESCRIPTION
Node 18 became the "current" version today. Add it to the CI version matrix.