### PR TITLE
chore: add `memory-fs` to the devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "mailgun": "^0.5.0",
     "mariadb": "^2.0.1-beta",
     "memcached": "^2.2.2",
+    "memory-fs": "^0.5.0",
     "mkdirp": "^1.0.4",
     "mongoose": "^5.3.12",
     "mysql": "^2.16.0",


### PR DESCRIPTION
It looks that `ncc` depends to `memory-fs` directly, but it is not in the dependencies.

https://github.com/vercel/ncc/blob/c9238cc7e7c0dfc39c0b2b9e4d556928d6dee41a/src/index.js#L6

This pull request will fix a broken build in https://github.com/vercel/ncc/pull/921