### PR TITLE
fix: gitignore should include release.config.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist/**/*.js
 !yarn.lock
 !.circleci
 !.github
+!release.config.js
 !.*ignore
 !readme.md
 !examples/

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  branches: ['main'],
+  tagFormat: '${version}',
+}


### PR DESCRIPTION
This file didn't get committed in https://github.com/vercel/ncc/pull/1015 because of the gitignore so this PR fixes it