### PR TITLE
test: migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepublishOnly": "node scripts/build.js --no-cache"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.441.0",
     "@azure/cosmos": "^3.17.3",
     "@bugsnag/js": "^7.21.0",
     "@ffmpeg-installer/ffmpeg": "^1.0.17",
@@ -31,7 +32,6 @@
     "apollo-server-express": "^2.2.2",
     "arg": "^5.0.2",
     "auth0": "^2.14.0",
-    "aws-sdk": "^2.1448.0",
     "axios": "^0.21.1",
     "azure-storage": "^2.10.2",
     "browserify-middleware": "^8.1.1",

--- a/test/integration/aws-sdk.js
+++ b/test/integration/aws-sdk.js
@@ -1,3 +1,3 @@
-const aws = require('aws-sdk');
+const { S3 } = require('@aws-sdk/client-s3');
 
-new aws.S3();
+new S3();


### PR DESCRIPTION
### Issue

From AWS SDK for JavaScript v2 [README](https://github.com/aws/aws-sdk-js):
> We are formalizing our plans to make the Maintenance Announcement (Phase 2) for AWS SDK for JavaScript v2 in 2023.

### Description

update `aws-sdk` integration test to use v3