### PR TITLE
feat: add `webpack` arg for customizing webpack config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ require('@vercel/ncc')('/path/to/input', {
   v8cache: false, // default
   quiet: false, // default
   debugLog: false, // default
-  webpack: (config) => config // default
+  customizeConfig: (config) => config // default
 }).then(({ code, map, assets }) => {
   console.log(code);
   // Assets is an object of asset file names to { source, permissions, symlinks }

--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,8 @@ require('@vercel/ncc')('/path/to/input', {
   target: 'es2015', // default
   v8cache: false, // default
   quiet: false, // default
-  debugLog: false // default
+  debugLog: false, // default
+  webpack: (config) => config // default
 }).then(({ code, map, assets }) => {
   console.log(code);
   // Assets is an object of asset file names to { source, permissions, symlinks }

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ function ncc (
     // webpack defaults to `module` and `main`, but that's
     // not really what node.js supports, so we reset it
     mainFields = ['main'],
-    webpack: extendWebpack = (config) => config
+    customizeConfig = (config) => config
   } = {}
 ) {
   // v8 cache not supported for ES modules
@@ -253,7 +253,7 @@ function ncc (
     }));
   }
 
-  const compiler = webpack(extendWebpack({
+  const compiler = webpack(customizeConfig({
     entry,
     cache: cache === false ? undefined : {
       type: "filesystem",

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,8 @@ function ncc (
     production = true,
     // webpack defaults to `module` and `main`, but that's
     // not really what node.js supports, so we reset it
-    mainFields = ['main']
+    mainFields = ['main'],
+    webpack: extendWebpack = (config) => config
   } = {}
 ) {
   // v8 cache not supported for ES modules
@@ -252,7 +253,7 @@ function ncc (
     }));
   }
 
-  const compiler = webpack({
+  const compiler = webpack(extendWebpack({
     entry,
     cache: cache === false ? undefined : {
       type: "filesystem",
@@ -383,7 +384,7 @@ function ncc (
       },
     },
     plugins
-  });
+  }));
   compiler.outputFileSystem = mfs;
   if (!watch) {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
This PR enables the base ncc webpack config to be customized or extended, similar to [NextJS](https://nextjs.org/docs/app/api-reference/next-config-js/webpack):

https://nextjs.org/docs/app/api-reference/next-config-js/webpack

The use cases of this feature are scenarios such as adding additional webpack rules or plugins, or configuring a path resolve alias.

The README has been updated for the programmatic invoke from Node.js to include the new `webpack` arg.