### PR TITLE
fix: add missing `--asset-builds` to cli help message 

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -31,7 +31,6 @@ Options:
   -a, --asset-builds       Build nested JS assets recursively, useful for
                            when code is loaded as an asset eg for workers.
   --no-source-map-register Skip source-map-register source map support
-
   -e, --external [mod]     Skip bundling 'mod'. Can be used many times
   -q, --quiet              Disable build summaries / non-error outputs
   -w, --watch              Start a watched build

--- a/src/cli.js
+++ b/src/cli.js
@@ -28,7 +28,10 @@ Options:
   -m, --minify             Minify output
   -C, --no-cache           Skip build cache population
   -s, --source-map         Generate source map
+  -a, --asset-builds       Build nested JS assets recursively, useful for
+                           when code is loaded as an asset eg for workers.
   --no-source-map-register Skip source-map-register source map support
+
   -e, --external [mod]     Skip bundling 'mod'. Can be used many times
   -q, --quiet              Disable build summaries / non-error outputs
   -w, --watch              Start a watched build


### PR DESCRIPTION
The `-a, --asset-builds` do exists and is useful in some circumstances(https://github.com/vercel/ncc/issues/1049), but it seems that the cli help message does not contain its usage description ( while `README.md` has the description).

This PR add the description of `--asset-builds` to the cli help message.