### PR TITLE
chore(docs): fix CI badge status display

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # ncc
 
-[![CI Status](https://github.com/vercel/ncc/actions/workflows/ci.yml/badge.svg)](https://github.com/vercel/ncc/actions?workflow=CI)
+[![CI Status](https://github.com/vercel/ncc/actions/workflows/ci.yml/badge.svg)](https://github.com/vercel/ncc/actions/workflows/ci.yml)
 
 Simple CLI for compiling a Node.js module into a single file,
 together with all its dependencies, gcc-style.


### PR DESCRIPTION
## Situation

The CI badge is showing an incorrect failing status.

<img width="529" height="206" alt="image" src="https://github.com/user-attachments/assets/8a522674-48da-48ef-b10a-8558bd4ece76" />


The badge for the CI workflow [.github/workflows/ci.yml](https://github.com/vercel/ncc/blob/main/.github/workflows/ci.yml), displayed in the [readme.md](https://github.com/vercel/ncc/blob/main/readme.md), shows "CI failing", although the action last ran successfully in the default `main` branch.

The badge is using the URL:

https://github.com/vercel/ncc/workflows/CI/badge.svg

The syntax of this URL is not in line with the GitHub documentation [Adding a workflow status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) which specifies the format:

```text
https://github.com/OWNER/REPOSITORY/actions/workflows/WORKFLOW-FILE/badge.svg
```

## Change

In the [readme.md](https://github.com/vercel/ncc/blob/main/readme.md) change the URL to

```text
https://github.com/vercel/ncc/actions/workflows/ci.yml/badge.svg
```

## Verification

Check the [readme.md](https://github.com/vercel/ncc/blob/main/readme.md) and confirm that the badge status conforms to the status of the latest [action run](https://github.com/vercel/ncc/actions?query=branch%3Amain) in the default `main` branch.

Currently this should be showing

<img width="107" height="38" alt="image" src="https://github.com/user-attachments/assets/8bacedf1-7833-4867-a46c-c2804ae8463f" />
