### PR TITLE
ci: remove Node.js 18 from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [18, 20]
+        node: [20]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
## Situation

The CI workflow [.github/workflows/ci.yml](https://github.com/vercel/ncc/blob/main/.github/workflows/ci.yml) currently tests against Node.js 18 and 20.

Referring to the [Node.js release schedule](https://github.com/nodejs/release#release-schedule) Node.js 18 has transitioned to end-of-life:

| Node.js | Status      | Date       |
| ------- | ----------- | ---------- |
| `18.x`  | End-of-Life | 2025-04-30 |

## Change

For the CI workflow [.github/workflows/ci.yml](https://github.com/vercel/ncc/blob/main/.github/workflows/ci.yml):

| Node.js | Change |
| ------- | ------ |
| `18.x`  | Remove |
| `20.x`  | Keep   |

Node.js 22 and 24 are not considered in this PR, since the workflow fails when attempting to use these versions. Any enhancement made to address workflow compatibility would need to be made in a separate PR.