### PR TITLE
Quality: Crash on malformed __NCC_OPTS env var in typescript loader

### DIFF
--- a/src/typescript.js
+++ b/src/typescript.js
@@ -1,7 +1,10 @@
-
 const { Module } = require('module');
 const m = new Module('', null);
-const { quiet, typescriptLookupPath } = JSON.parse(process.env.__NCC_OPTS || '{}');
+let opts = {};
+try {
+  opts = JSON.parse(process.env.__NCC_OPTS || '{}') || {};
+} catch (e) {}
+const { quiet, typescriptLookupPath } = opts;
 m.paths = Module._nodeModulePaths(process.env.TYPESCRIPT_LOOKUP_PATH || typescriptLookupPath || (process.cwd() + '/'));
 let typescript;
 try {


### PR DESCRIPTION
## Description

JSON.parse(process.env.__NCC_OPTS || '{}') throws SyntaxError on invalid JSON; destructuring then throws TypeError if the result is not an object (e.g. env var set to a string or number). This crashes the entire ncc process whenever TypeScript support is used.

## Changes

- `src/typescript.js` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `medium`
