### PR TITLE
feat: support TypeScript 6 transpile builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "terser": "^5.33.0",
     "the-answer": "^1.0.0",
     "tiny-json-http": "^7.5.1",
-    "ts-loader": "^9.4.4",
+    "ts-loader": "^9.5.7",
     "tsconfig-paths": "^4.2.0",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "twilio": "^3.23.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15752,10 +15752,10 @@ ts-invariant@^0.4.0:
   dependencies:
     tslib "^1.9.3"
 
-ts-loader@^9.4.4:
-  version "9.5.1"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.5.1.tgz#63d5912a86312f1fbe32cef0859fb8b2193d9b89"
-  integrity sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==
+ts-loader@^9.5.7:
+  version "9.5.7"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.5.7.tgz#582663e853646e18506cd5cc79feb354952731c0"
+  integrity sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^5.0.0"


### PR DESCRIPTION
## Summary

Updates `ts-loader` to `9.5.7` so ncc's bundled TypeScript loader preserves configured `rootDir` during `transpileModule` builds.

This fixes TypeScript 6 `TS5011` failures like:

```text
TS5011: The common source directory of 'tsconfig.json' is './actions/javascript/...'. The 'rootDir' setting must be explicitly set to this or another path to adjust your output's file layout.
```

`ts-loader` fixed this upstream in https://github.com/TypeStrong/ts-loader/pull/1679.

## Verification

- Ran `yarn build`