### PR TITLE
feat: delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @styfle @Timer


### PR DESCRIPTION
This is how our other repos are managed - they just require one approval by a Vercelian.

For example, see https://github.com/vercel/ms