### PR TITLE
feat: switch npm releases to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node: [22, 24, 26]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # required for npm trusted publishing (OIDC)
     steps:
     - uses: actions/checkout@v5
     # https://github.com/nodejs/node-gyp#installation
@@ -65,5 +70,4 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.node == 22 && github.event_name == 'push' && github.ref == 'refs/heads/main'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
       run: npx semantic-release@19.0.5


### PR DESCRIPTION
Similar to https://github.com/vercel/nft/pull/585

Configure a trusted publisher on npm:

1. [Package settings → Trusted publishing](https://www.npmjs.com/package/@vercel/ncc/access)
2. Provider: **GitHub Actions**
3. Repository: `vercel/ncc`
4. Workflow filename: `ci.yml`