### PR TITLE
feat: use canonical package repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@vercel/ncc",
   "description": "Simple CLI for compiling a Node.js module into a single file, together with all its dependencies, gcc-style.",
   "version": "0.0.0-development",
-  "repository": "vercel/ncc",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/ncc.git"
+  },
   "license": "MIT",
   "main": "./dist/ncc/index.js",
   "bin": {


### PR DESCRIPTION
We must use explicit git repository metadata in package.json so npm trusted publishing can match the GitHub repo.