### PR TITLE
feat: publish using node@24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 30
     env:
       COREPACK_DEFAULT_TO_LATEST: '0'
+      COREPACK_ENABLE_STRICT: '0'
     strategy:
       fail-fast: false
       matrix:
@@ -57,7 +58,7 @@ jobs:
         node-version: ${{ matrix.node }}
         check-latest: true
     - name: Install Dependencies
-      run: pnpm add --global node-gyp && pnpm install --frozen-lockfile
+      run: npm i -g node-gyp && pnpm install --frozen-lockfile
     - name: Build Test Binary
       run: pnpm build-test-binary
     - name: Build
@@ -71,5 +72,4 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.node == 24 && github.event_name == 'push' && github.ref == 'refs/heads/main'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COREPACK_ENABLE_STRICT: '0'
       run: pnpm --dir publish install --ignore-workspace --frozen-lockfile && ./publish/node_modules/.bin/semantic-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
   test:
     name: Node ${{ matrix.node }} and ${{ matrix.os }}
     timeout-minutes: 30
+    env:
+      COREPACK_DEFAULT_TO_LATEST: '0'
     strategy:
       fail-fast: false
       matrix:
@@ -28,7 +30,7 @@ jobs:
       pull-requests: write # to be able to comment on released pull requests
       id-token: write # required for npm trusted publishing (OIDC)
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     # https://github.com/nodejs/node-gyp#installation
     - name: Use Python 3.11
       uses: actions/setup-python@v6
@@ -46,9 +48,8 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev
-    - uses: pnpm/action-setup@v4
-      with:
-        run_install: false
+    - name: Enable Corepack
+      run: corepack enable pnpm
     - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v6
       with:
@@ -64,10 +65,11 @@ jobs:
     - name: Run Tests
       run: pnpm test
     - name: Coverage
-      if: matrix.os == 'ubuntu-latest' && matrix.node == 22 # only run once
+      if: matrix.os == 'ubuntu-latest' && matrix.node == 24 # only run once
       run: pnpm test-coverage
     - name: Maybe Release
-      if: matrix.os == 'ubuntu-latest' && matrix.node == 22 && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: matrix.os == 'ubuntu-latest' && matrix.node == 24 && github.event_name == 'push' && github.ref == 'refs/heads/main'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COREPACK_ENABLE_STRICT: '0'
       run: pnpm --dir publish install --ignore-workspace --frozen-lockfile && ./publish/node_modules/.bin/semantic-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     # https://github.com/nodejs/node-gyp#installation
-    - name: Use Python 3.11
+    - name: Use Python 3.12
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     # https://github.com/hargasinski/node-canvas/blob/e7abe64833d13ec96449c827b1e14befbdf3105d/.github/workflows/ci.yaml#L70
     - name: "macOS dependencies"
       if: matrix.os == 'macos-latest'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "main": "./dist/ncc/index.js",
   "bin": {
-    "ncc": "./dist/ncc/cli.js"
+    "ncc": "dist/ncc/cli.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
npm is outdated and doesn't support trusted publishing so we need to use a newer node version to publish which implicily updates npm

(also we don't want corepack strict check to block npm)