### PR TITLE
feat(ci): upgrade python and remove LLVM LTO flags from MSVC build to fix Node 26 Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     # https://github.com/nodejs/node-gyp#installation
-    - name: Use Python 3.12
+    - name: Use Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.14'
     # https://github.com/hargasinski/node-canvas/blob/e7abe64833d13ec96449c827b1e14befbdf3105d/.github/workflows/ci.yaml#L70
     - name: "macOS dependencies"
       if: matrix.os == 'macos-latest'

--- a/test/binary/binding.gyp
+++ b/test/binary/binding.gyp
@@ -1,10 +1,29 @@
 {
+  "variables": {
+    "lto_jobs%": ""
+  },
   "targets": [
     {
       "target_name": "hello",
       "sources": [ "hello.cc" ],
       "include_dirs": [
         "<!(node -e \"require('nan')\")"
+      ],
+      "conditions": [
+        ["OS=='win'", {
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "AdditionalOptions!": ["-flto=thin", "-flto=full"]
+            },
+            "VCLinkerTool": {
+              "AdditionalOptions!": [
+                "-flto=thin",
+                "-flto=full",
+                "/opt:lldltojobs=<(lto_jobs)"
+              ]
+            }
+          }
+        }]
       ]
     }
   ]


### PR DESCRIPTION
## Root Cause

Node.js 26 on Windows is compiled using Clang with thin LTO enabled (`enable_thin_lto=true`, `lto_jobs=2`). When `node-gyp rebuild` runs without `--nodedir`, it generates `build/config.gypi` from the running Node.js binary's `process.config`. This causes Node.js's `common.gypi` to inject LLVM/Clang-specific flags into the MSVC build:

- `-flto=thin` → compiler/linker warning (ignored by MSVC)
- `/opt:lldltojobs=2` → **fatal linker error `LNK1117`** (MSVC does not understand LLVM LTO job flags)

## Fix

Modified `test/binary/binding.gyp` to strip the incompatible LLVM LTO flags when building on Windows with MSVC:

- Added a `"lto_jobs%": ""` default variable as a safe fallback for Node versions that do not define this variable
- Added a Windows-specific `conditions` block using GYP's `AdditionalOptions!` list-removal operator to remove `-flto=thin`, `-flto=full`, and `/opt:lldltojobs=<(lto_jobs)` from both `VCCLCompilerTool` and `VCLinkerTool` options

The fix is a no-op on Node 22/24 (LTO not enabled, no flags to remove) and does not affect Linux or macOS builds.