### PR TITLE
fix: preserve runtime createRequire in ESM builds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -385,7 +385,10 @@ function ncc (
         }
       ],
       parser: {
-        javascript: { importMeta: false },
+        javascript: {
+          createRequire: false,
+          importMeta: false
+        },
       },
     },
     plugins

--- a/test/integration/create-require-runtime.mjs
+++ b/test/integration/create-require-runtime.mjs
@@ -1,0 +1,1 @@
+import "./create-require-runtime/input.ts";

--- a/test/integration/create-require-runtime.mjs.stdout
+++ b/test/integration/create-require-runtime.mjs.stdout
@@ -1,0 +1,1 @@
+runtime-require-ok

--- a/test/integration/create-require-runtime/input.ts
+++ b/test/integration/create-require-runtime/input.ts
@@ -1,0 +1,15 @@
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+
+const require = createRequire(process.cwd());
+const runtimeModulePath = resolve(
+  process.cwd(),
+  "test/integration/create-require-runtime/runtime.json"
+);
+const { sentinel } = require(runtimeModulePath);
+
+if (sentinel !== "runtime-require-ok") {
+  throw new Error(`Unexpected runtime module value: ${sentinel}`);
+}
+
+console.log(sentinel);

--- a/test/integration/create-require-runtime/runtime.json
+++ b/test/integration/create-require-runtime/runtime.json
@@ -1,0 +1,3 @@
+{
+  "sentinel": "runtime-require-ok"
+}


### PR DESCRIPTION
## Problem

Since 0.38.2, an ESM build can replace a runtime
`createRequire(...)` binding with `undefined`, causing the later runtime
`require(...)` call to throw.

## Change

- Disable Webpack's `createRequire` parser handling in ncc so Node evaluates
  the call at runtime.
- Add a normal integration fixture with an `.mjs` entry that imports the
  TypeScript runtime payload and loads a runtime-selected JSON module.

This keeps the fix at ncc's Webpack configuration boundary and covers the
reported runtime behavior without changing dependency tracing.

## Validation

- `node scripts/build.js --no-cache`
- `node --expose-gc --max_old_space_size=4096 node_modules/jest/bin/jest.js test/integration.test.js --runInBand --testNamePattern create-require-runtime`
  - 1 passed
- `pnpm test -- test/unit.test.js`
  - 28 passed
- `node --expose-gc --max_old_space_size=4096 node_modules/jest/bin/jest.js --runInBand test/integration.test.js --testNamePattern='^(?!should execute "ncc run (?:axios\.js|canvas\.js|isomorphic-unfetch\.js|request-ts\.ts|request\.js|sharp\.js|socket\.io\.js)"$).*'`
  - 62 passed; 7 local environment-dependent cases skipped
- Negative control with Webpack's `createRequire` parsing restored reproduced
  `TypeError: input_require is not a function`.

## Risk

The parser option applies to all JavaScript handled by ncc. It intentionally
preserves `createRequire` for Node to evaluate at runtime, so modules selected
only at runtime must still be deployed with the bundle.

The cross-platform Node 22/24/26 matrix remains for CI. A local CLI watch test
failed with Watchpack `EMFILE` errors and reproduced identically on
`origin/main`, so it is not attributed to this change.

## Out of scope

- Changing how ncc traces or deploys runtime-selected modules.
- Dependency or lockfile updates.

## Issue linkage

Fixes #1312
