### PR TITLE
fix: support TypeScript project references

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -369,6 +369,9 @@ function ncc (
                 module: 'esnext',
                 target: 'esnext',
                 ...fullTsconfig.compilerOptions,
+                // ncc bundles the root project and its dependencies as one compilation.
+                // Disable composite's implicit rootDir so referenced sources are included.
+                composite: false,
                 allowSyntheticDefaultImports: true,
                 noEmit: false,
                 outDir: '//'

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -26,11 +26,13 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
       opts = JSON.parse(opts);
     } catch (_) {}
 
-    // set env variable so tsconfig-paths can find the config
-    process.env.TS_NODE_PROJECT = `${testDir}/tsconfig.json`;
     // find the name of the input file (e.g input.ts)
-    const inputFile = fs.readdirSync(testDir).find(file => file.includes("input"));
-    await ncc(`${testDir}/${inputFile}`, Object.assign({
+    const rootInput = fs.readdirSync(testDir).find(file => file.includes("input"));
+    const inputDir = rootInput ? testDir : `${testDir}/app`;
+    const inputFile = rootInput || fs.readdirSync(inputDir).find(file => file.includes("input"));
+    // set env variable so tsconfig-paths can find the config
+    process.env.TS_NODE_PROJECT = `${inputDir}/tsconfig.json`;
+    await ncc(`${inputDir}/${inputFile}`, Object.assign({
       assetBuilds: true,
       transpileOnly: true,
       customEmit (path) {

--- a/test/unit/ts-project-references/app/input.ts
+++ b/test/unit/ts-project-references/app/input.ts
@@ -1,0 +1,3 @@
+import { hello } from '../lib/index';
+
+console.log(hello());

--- a/test/unit/ts-project-references/app/tsconfig.json
+++ b/test/unit/ts-project-references/app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist"
+  },
+  "include": ["input.ts"],
+  "references": [
+    {
+      "path": "../lib"
+    }
+  ]
+}

--- a/test/unit/ts-project-references/lib/index.ts
+++ b/test/unit/ts-project-references/lib/index.ts
@@ -1,0 +1,3 @@
+export function hello() {
+  return 'Hello, World!';
+}

--- a/test/unit/ts-project-references/lib/tsconfig.json
+++ b/test/unit/ts-project-references/lib/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist"
+  }
+}

--- a/test/unit/ts-project-references/opt.json
+++ b/test/unit/ts-project-references/opt.json
@@ -1,0 +1,4 @@
+{
+  "cache": false,
+  "transpileOnly": false
+}

--- a/test/unit/ts-project-references/output-coverage.js
+++ b/test/unit/ts-project-references/output-coverage.js
@@ -1,0 +1,21 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+var __webpack_exports__ = {};
+
+;// CONCATENATED MODULE: ./test/unit/ts-project-references/lib/index.ts
+function hello() {
+    return 'Hello, World!';
+}
+
+;// CONCATENATED MODULE: ./test/unit/ts-project-references/app/input.ts
+
+console.log(hello());
+
+module.exports = __webpack_exports__;
+/******/ })()
+;

--- a/test/unit/ts-project-references/output.js
+++ b/test/unit/ts-project-references/output.js
@@ -1,0 +1,21 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+var __webpack_exports__ = {};
+
+;// CONCATENATED MODULE: ./test/unit/ts-project-references/lib/index.ts
+function hello() {
+    return 'Hello, World!';
+}
+
+;// CONCATENATED MODULE: ./test/unit/ts-project-references/app/input.ts
+
+console.log(hello());
+
+module.exports = __webpack_exports__;
+/******/ })()
+;


### PR DESCRIPTION
## Summary
- allow ncc to bundle TypeScript composite projects that import referenced sibling sources
- keep composite build artifacts out of ncc's single-bundle compilation
- add a regression fixture matching the app/lib workspace reported in the issue
- run the regression through the standard unit golden-output runner in normal and coverage modes

## Root cause
When composite is enabled, TypeScript implicitly scopes rootDir to the directory containing the project tsconfig. ncc compiles the entry point and its imported sources as one webpack compilation, so a referenced sibling project was rejected with TS6059.

ncc already controls emit-related compiler options for its internal compilation. Disabling composite there preserves the single-bundle model while leaving the user's tsconfig unchanged.

## Tests
- pnpm build-test-binary
- pnpm build
- pnpm test (119 passed)
- pnpm test-coverage
- pnpm test test/unit.test.js --runInBand --testNamePattern=ts-project-references
- pnpm test-coverage test/unit.test.js --testNamePattern=ts-project-references

Fixes #1212
