### PR TITLE
feat: Add TypeScript declarations for the programmatic API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ dist/**/*.js
 !scripts
 !src
 !src/*.js
+!src/*.d.ts
 !test
+!test/types/
+!test/types/**
 !test/integration
 !test/integration/*.json
 !test/integration/*.js

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "license": "MIT",
   "main": "./dist/ncc/index.js",
+  "types": "./dist/ncc/index.d.ts",
   "bin": {
     "ncc": "dist/ncc/cli.js"
   },
@@ -18,6 +19,7 @@
     "build": "node scripts/build.js",
     "build-test-binary": "cd test/binary && node-gyp rebuild && cp build/Release/hello.node ../integration/hello.node",
     "test": "node --expose-gc --max_old_space_size=4096 node_modules/jest/bin/jest.js",
+    "test-types": "tsc --noEmit -p test/types",
     "test-coverage": "node --expose-gc --max_old_space_size=4096 node_modules/jest/bin/jest.js --runInBand --coverage --globals \"{\\\"coverage\\\":true}\"",
     "prepublishOnly": "node scripts/build.js --no-cache"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -38,7 +38,7 @@ async function main() {
     }
   );
   checkUnknownAssets('index', Object.keys(indexAssets).filter(asset =>
-    !asset.startsWith('locales/') && asset !== 'worker.js' && asset !== 'index1.js' && asset !== 'minify.js'
+    !asset.startsWith('locales/') && asset !== 'worker.js' && asset !== 'index1.js' && asset !== 'minify.js' && !asset.endsWith('.d.ts')
   ));
 
   const { code: relocateLoader, assets: relocateLoaderAssets } = await ncc(
@@ -104,6 +104,10 @@ async function main() {
 
   writeFileSync(__dirname + "/../dist/ncc/cli.js", cli, { mode: 0o777 });
   writeFileSync(__dirname + "/../dist/ncc/index.js", index);
+  writeFileSync(
+    __dirname + "/../dist/ncc/index.d.ts",
+    readFileSync(__dirname + "/../src/index.d.ts")
+  );
   writeFileSync(__dirname + "/../dist/ncc/typescript.js", readFileSync(__dirname + "/../src/typescript.js"));
   writeFileSync(__dirname + "/../dist/ncc/sourcemap-register.js", sourcemapSupport);
   writeFileSync(__dirname + "/../dist/ncc/loaders/relocate-loader.js", relocateLoader);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,74 @@
+/// <reference types="node" />
+
+declare namespace ncc {
+  interface Asset {
+    source: Buffer | string;
+    permissions?: number;
+  }
+
+  interface BuildResult {
+    code: string;
+    map: string | undefined;
+    assets: Record<string, Asset>;
+    symlinks: Record<string, string>;
+    stats: unknown;
+  }
+
+  interface WatchBuildResult extends Partial<BuildResult> {
+    err?: Error | string;
+  }
+
+  interface Watcher {
+    handler(callback: (result: WatchBuildResult) => void): void;
+    rebuild(callback: () => void): void;
+    close(): void;
+  }
+
+  type Externals =
+    | string[]
+    | Record<string, string>;
+
+  interface Options {
+    cache?: string | false;
+    externals?: Externals;
+    filterAssetBase?: string;
+    minify?: boolean;
+    sourceMap?: boolean;
+    assetBuilds?: boolean;
+    sourceMapBasePrefix?: string;
+    sourceMapRegister?: boolean;
+    watch?: boolean;
+    license?: string;
+    target?: string;
+    v8cache?: boolean;
+    quiet?: boolean;
+    debugLog?: boolean;
+    transpileOnly?: boolean;
+    filename?: string;
+    esm?: boolean;
+    production?: boolean;
+    mainFields?: string[];
+    existingAssetNames?: string[];
+    customEmit?: (
+      path: string,
+      outOrAsset?: boolean
+    ) => void | false | string;
+  }
+}
+
+declare function ncc(
+  input: string,
+  options?: ncc.Options & { watch?: false }
+): Promise<ncc.BuildResult>;
+
+declare function ncc(
+  input: string,
+  options: ncc.Options & { watch: true }
+): ncc.Watcher;
+
+declare function ncc(
+  input: string,
+  options?: ncc.Options
+): Promise<ncc.BuildResult> | ncc.Watcher;
+
+export = ncc;

--- a/test/types/api.ts
+++ b/test/types/api.ts
@@ -1,0 +1,68 @@
+import ncc = require("@vercel/ncc");
+
+async function buildOnce() {
+  const result = await ncc("./input.js", {
+    cache: false,
+    minify: true,
+    sourceMap: true,
+    assetBuilds: true,
+    externals: ["express"],
+    filterAssetBase: process.cwd(),
+    sourceMapBasePrefix: "../",
+    sourceMapRegister: true,
+    license: "LICENSES.txt",
+    target: "es2015",
+    v8cache: false,
+    quiet: true,
+    debugLog: false,
+    transpileOnly: true,
+    filename: "index.js",
+    esm: false,
+    production: true,
+    mainFields: ["main"],
+    customEmit(path) {
+      if (path.endsWith(".json")) return false;
+    }
+  });
+
+  const code: string = result.code;
+  const map: string | undefined = result.map;
+  const assets: ncc.Asset = result.assets["asset.bin"] || { source: "" };
+  const source: Buffer | string = assets.source;
+  const perms: number | undefined = assets.permissions;
+  const symlink: string | undefined = result.symlinks["link"];
+  const stats: unknown = result.stats;
+
+  return { code, map, source, perms, symlink, stats };
+}
+
+function buildWatch() {
+  const watcher = ncc("./input.js", { watch: true, quiet: true });
+
+  watcher.handler(({ err, code, map, assets, symlinks, stats }) => {
+    if (err) return;
+    if (code) {
+      void code.length;
+    }
+    void map;
+    void assets;
+    void symlinks;
+    void stats;
+  });
+
+  watcher.rebuild(() => {});
+  watcher.close();
+}
+
+async function mappedExternals() {
+  await ncc("./input.js", {
+    externals: {
+      lodash: "lodash",
+      "/^react($|\\/)/": "react"
+    }
+  });
+}
+
+void buildOnce();
+void buildWatch();
+void mappedExternals();

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "baseUrl": "../..",
+    "paths": {
+      "@vercel/ncc": ["src/index.d.ts"]
+    }
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
Fixes #1238

Adds TypeScript declarations for the programmatic `@vercel/ncc` API and points `package.json` `types` at them. The declarations cover the documented build options, watch-mode overloads (`handler` / `rebuild` / `close`), and the real return shape (`code`, `map`, `assets`, `symlinks`, `stats`). `scripts/build.js` copies `src/index.d.ts` into `dist/ncc/index.d.ts` so the published package ships the types next to `main`.

Verified with `pnpm test-types` (strict check over a small consumer fixture), `pnpm build` (confirms `dist/ncc/index.d.ts` is emitted), and `pnpm exec jest test/unit.test.js test/watcher.test.js --runInBand` (29 passed). Full `pnpm test` hits two environment-only flakes on this host (socket.io needs free `:3000`; the `TYPESCRIPT_LOOKUP_PATH=/tmp/nowhere` CLI case finds typescript under `/tmp/node_modules`); both fail the same way without this change.