### PR TITLE
Allow TypeScript configs that set allowImportingTsExtensions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -365,12 +365,18 @@ function ncc (
             options: {
               transpileOnly,
               compiler: eval('__dirname + "/typescript.js"'),
+              // ncc emits JS, so noEmit is forced off. TS5096 then fires if the
+              // project enabled allowImportingTsExtensions; ignore that config error.
+              ignoreDiagnostics: (fullTsconfig.compilerOptions || {}).allowImportingTsExtensions
+                ? [5096]
+                : [],
               compilerOptions: {
                 module: 'esnext',
                 target: 'esnext',
                 ...fullTsconfig.compilerOptions,
                 allowSyntheticDefaultImports: true,
                 noEmit: false,
+                emitDeclarationOnly: false,
                 outDir: '//'
               }
             }

--- a/test/cli.js
+++ b/test/cli.js
@@ -71,6 +71,13 @@ module.exports = [
     expect: { code: 0 }
   },
   {
+    args: ["build", "-o", "tmp", "test/fixtures/ts-allow-importing-ts-extensions/input.ts"],
+    expect (code, stdout, stderr) {
+      const fs = require('fs');
+      return code === 0 && fs.readFileSync(join('tmp', 'index.js'), 'utf8').indexOf('value') !== -1;
+    }
+  },
+  {
     args: ["build", "-o", "tmp", "test/fixtures/test.cjs"],
     expect (code, stdout, stderr) {
       return stdout.toString().indexOf(join('tmp', 'index.cjs')) !== -1;

--- a/test/fixtures/ts-allow-importing-ts-extensions/dep.ts
+++ b/test/fixtures/ts-allow-importing-ts-extensions/dep.ts
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/test/fixtures/ts-allow-importing-ts-extensions/input.ts
+++ b/test/fixtures/ts-allow-importing-ts-extensions/input.ts
@@ -1,0 +1,2 @@
+import { value } from './dep.ts';
+console.log(value);

--- a/test/fixtures/ts-allow-importing-ts-extensions/tsconfig.json
+++ b/test/fixtures/ts-allow-importing-ts-extensions/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
Fixes vercel/ncc#1146

ncc already forces noEmit false so it can emit JavaScript. User tsconfig files that set allowImportingTsExtensions with noEmit true then fail with TS5096.

Keep emitting JavaScript, clear emitDeclarationOnly, and ignore TS5096 when the project enabled allowImportingTsExtensions so .ts import specifiers still typecheck.