### PR TITLE
fix: resolve ESM-only package exports maps (fixes #1311)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,11 @@ function ncc (
     extensions: SUPPORTED_EXTENSIONS,
     exportsFields: ["exports"],
     importsFields: ["imports"],
-    conditionNames: ["require", "node", production ? "production" : "development"]
+    // Include "import" so ESM-only packages (exports.import without
+    // require/default) still resolve under CJS resolution. "require"
+    // stays first so dual packages keep their CJS entry.
+    // https://github.com/vercel/ncc/issues/1311
+    conditionNames: ["require", "import", "node", production ? "production" : "development"]
   });
   const esmDeps = () => ({
     mainFields,

--- a/test/unit/exports-import-only/input.js
+++ b/test/unit/exports-import-only/input.js
@@ -1,0 +1,2 @@
+import { load } from './wrapper.cjs';
+console.log(load());

--- a/test/unit/exports-import-only/node_modules/@test/import-only/lib/core.d.ts
+++ b/test/unit/exports-import-only/node_modules/@test/import-only/lib/core.d.ts
@@ -1,0 +1,1 @@
+export const ok: string;

--- a/test/unit/exports-import-only/node_modules/@test/import-only/lib/core.js
+++ b/test/unit/exports-import-only/node_modules/@test/import-only/lib/core.js
@@ -1,0 +1,1 @@
+export const ok = 'import-only';

--- a/test/unit/exports-import-only/node_modules/@test/import-only/package.json
+++ b/test/unit/exports-import-only/node_modules/@test/import-only/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@test/import-only",
+  "type": "module",
+  "main": "lib/core.js",
+  "types": "lib/core.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/core.d.ts",
+      "import": "./lib/core.js"
+    }
+  }
+}

--- a/test/unit/exports-import-only/output-coverage.js
+++ b/test/unit/exports-import-only/output-coverage.js
@@ -1,0 +1,96 @@
+/******/ var __webpack_modules__ = ({
+
+/***/ 122:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+// CJS require of an ESM-only package (exports.import, no require/default).
+// https://github.com/vercel/ncc/issues/1311
+module.exports = {
+  load: () => __nccwpck_require__(449)
+};
+
+
+/***/ }),
+
+/***/ 449:
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
+
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   ok: () => (/* binding */ ok)
+/* harmony export */ });
+const ok = 'import-only';
+
+
+/***/ })
+
+/******/ });
+/************************************************************************/
+/******/ // The module cache
+/******/ var __webpack_module_cache__ = {};
+/******/ 
+/******/ // The require function
+/******/ function __nccwpck_require__(moduleId) {
+/******/ 	// Check if module is in cache
+/******/ 	var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 	if (cachedModule !== undefined) {
+/******/ 		return cachedModule.exports;
+/******/ 	}
+/******/ 	// Create a new module (and put it into the cache)
+/******/ 	var module = __webpack_module_cache__[moduleId] = {
+/******/ 		// no module.id needed
+/******/ 		// no module.loaded needed
+/******/ 		exports: {}
+/******/ 	};
+/******/ 
+/******/ 	// Execute the module function
+/******/ 	var threw = true;
+/******/ 	try {
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 		threw = false;
+/******/ 	} finally {
+/******/ 		if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 	}
+/******/ 
+/******/ 	// Return the exports of the module
+/******/ 	return module.exports;
+/******/ }
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/asset-relocator-loader */
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = decodeURIComponent(new URL('.', import.meta.url).pathname).slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ (() => {
+/******/ 	// define getter functions for harmony exports
+/******/ 	__nccwpck_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ })();
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ (() => {
+/******/ 	__nccwpck_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ })();
+/******/ 
+/******/ /* webpack/runtime/make namespace object */
+/******/ (() => {
+/******/ 	// define __esModule on exports
+/******/ 	__nccwpck_require__.r = (exports) => {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/ })();
+/******/ 
+/************************************************************************/
+var __webpack_exports__ = {};
+/* harmony import */ var _wrapper_cjs__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(122);
+
+console.log((0,_wrapper_cjs__WEBPACK_IMPORTED_MODULE_0__.load)());
+

--- a/test/unit/exports-import-only/output.js
+++ b/test/unit/exports-import-only/output.js
@@ -1,0 +1,96 @@
+/******/ var __webpack_modules__ = ({
+
+/***/ 122:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+// CJS require of an ESM-only package (exports.import, no require/default).
+// https://github.com/vercel/ncc/issues/1311
+module.exports = {
+  load: () => __nccwpck_require__(449)
+};
+
+
+/***/ }),
+
+/***/ 449:
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
+
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   ok: () => (/* binding */ ok)
+/* harmony export */ });
+const ok = 'import-only';
+
+
+/***/ })
+
+/******/ });
+/************************************************************************/
+/******/ // The module cache
+/******/ var __webpack_module_cache__ = {};
+/******/ 
+/******/ // The require function
+/******/ function __nccwpck_require__(moduleId) {
+/******/ 	// Check if module is in cache
+/******/ 	var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 	if (cachedModule !== undefined) {
+/******/ 		return cachedModule.exports;
+/******/ 	}
+/******/ 	// Create a new module (and put it into the cache)
+/******/ 	var module = __webpack_module_cache__[moduleId] = {
+/******/ 		// no module.id needed
+/******/ 		// no module.loaded needed
+/******/ 		exports: {}
+/******/ 	};
+/******/ 
+/******/ 	// Execute the module function
+/******/ 	var threw = true;
+/******/ 	try {
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __nccwpck_require__);
+/******/ 		threw = false;
+/******/ 	} finally {
+/******/ 		if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 	}
+/******/ 
+/******/ 	// Return the exports of the module
+/******/ 	return module.exports;
+/******/ }
+/******/ 
+/************************************************************************/
+/******/ /* webpack/runtime/asset-relocator-loader */
+/******/ if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = decodeURIComponent(new URL('.', import.meta.url).pathname).slice(import.meta.url.match(/^file:\/\/\/\w:/) ? 1 : 0, -1) + "/";
+/******/ 
+/******/ /* webpack/runtime/define property getters */
+/******/ (() => {
+/******/ 	// define getter functions for harmony exports
+/******/ 	__nccwpck_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ })();
+/******/ 
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ (() => {
+/******/ 	__nccwpck_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ })();
+/******/ 
+/******/ /* webpack/runtime/make namespace object */
+/******/ (() => {
+/******/ 	// define __esModule on exports
+/******/ 	__nccwpck_require__.r = (exports) => {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/ })();
+/******/ 
+/************************************************************************/
+var __webpack_exports__ = {};
+/* harmony import */ var _wrapper_cjs__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(122);
+
+console.log((0,_wrapper_cjs__WEBPACK_IMPORTED_MODULE_0__.load)());
+

--- a/test/unit/exports-import-only/package.json
+++ b/test/unit/exports-import-only/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/unit/exports-import-only/wrapper.cjs
+++ b/test/unit/exports-import-only/wrapper.cjs
@@ -1,0 +1,5 @@
+// CJS require of an ESM-only package (exports.import, no require/default).
+// https://github.com/vercel/ncc/issues/1311
+module.exports = {
+  load: () => require('@test/import-only')
+};


### PR DESCRIPTION
fixes #1311

ncc fails on packages whose exports map has import/types but no default/require, like @actions/core 3.x.

We add import to CJS conditionNames. require stays first so dual packages still pick CJS.

there is a unit fixture named exports-import-only.